### PR TITLE
Add solver-agnostic MCS region validity checks

### DIFF
--- a/cnapy/gui_elements/mcs_dialog.py
+++ b/cnapy/gui_elements/mcs_dialog.py
@@ -686,7 +686,7 @@ class MCSDialog(QDialog):
             if last_is_dash and (semantic in ("multiplication", "division")):
                 errors += f"ERROR in {equation}:\n* or / must not follow on + or -\n"
             if last_is_number and (semantic == "reaction"):
-                errors += f"ERROR in {equation}:\nA number must not follow on a reaction ID\n"
+                errors += f"ERROR in {equation}:\nA reaction must not directly follow on a number without a mathematical operation\n"
             if last_is_reaction and (semantic == "reaction"):
                 errors += f"ERROR in {equation}:\nA reaction must not follow on a reaction ID\n"
             if last_is_number and (semantic == "number"):


### PR DESCRIPTION
Regarding #310, this commit adds a quite extensive validity check for all entered desired and target regions, depending on whether they are on the left or the right side of the equation. All tested cases are returned as error-describing strings. And if an error occurs (which is checked when "Compute MCS" is pressed), the errors are shown in a message box so that the user can fix them. In addition, the MCS computation will not be performed.