### PR TITLE
Add identifiers.org annotation check

### DIFF
--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -334,6 +334,7 @@ class MetabolitesMask(QWidget):
                 return True
 
     def check_in_identifiers_org(self):
+        self.setCursor(Qt.BusyCursor)
         rows = self.annotation.rowCount()
         valid_green = QColor(0, 255, 0)
         invalid_red = QColor(255, 0, 0)
@@ -357,9 +358,9 @@ class MetabolitesMask(QWidget):
                 values = [values]
 
             for value in values:
-                is_valid, connection_error = check_identifiers_org_entry(key, value)
+                identifiers_org_result = check_identifiers_org_entry(key, value)
 
-                if connection_error:
+                if identifiers_org_result.connection_error:
                     msgBox = QMessageBox()
                     msgBox.setWindowTitle("Connection error!")
                     msgBox.setTextFormat(Qt.RichText)
@@ -368,21 +369,26 @@ class MetabolitesMask(QWidget):
                     msgBox.exec()
                     break
 
-                if (not is_valid) and (":" in value):
+                if (not identifiers_org_result.is_key_value_pair_valid) and (":" in value):
                     split_value = value.split(":")
-                    is_valid, connection_error = check_identifiers_org_entry(split_value[0], split_value[1])
+                    identifiers_org_result = check_identifiers_org_entry(split_value[0], split_value[1])
 
 
-                if is_valid:
-                    color = valid_green
+                if identifiers_org_result.is_key_valid:
+                    key_color = valid_green
                 else:
-                    color = invalid_red
+                    key_color = invalid_red
+                self.annotation.item(i, 0).setBackground(key_color)
 
-                self.annotation.item(i, 0).setBackground(color)
-                self.annotation.item(i, 1).setBackground(color)
+                if identifiers_org_result.is_key_value_pair_valid:
+                    value_color = valid_green
+                else:
+                    value_color = invalid_red
+                self.annotation.item(i, 1).setBackground(value_color)
 
-                if not is_valid:
+                if not identifiers_org_result.is_key_value_pair_valid:
                     break
+            self.setCursor(Qt.ArrowCursor)
 
     def validate_name(self):
         with self.appdata.project.cobra_py_model as model:

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -2,13 +2,15 @@
 
 import cobra
 from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtGui import QColor, QIcon
 from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel,
-                            QLineEdit, QMenu, QMessageBox, QPushButton,
+                            QLineEdit, QMenu, QMessageBox, QPushButton, QSizePolicy,
                             QSplitter, QTableWidget, QTableWidgetItem,
                             QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white
+from cnapy.utils_for_cnapy_api import check_identifiers_org_entry
 
 
 class MetaboliteList(QWidget):
@@ -224,8 +226,21 @@ class MetabolitesMask(QWidget):
         layout.addItem(l)
 
         l = QVBoxLayout()
+
+        l3 = QHBoxLayout()
         label = QLabel("Annotations:")
-        l.addWidget(label)
+        l3.addWidget(label)
+
+        check_button = QPushButton("identifiers.org check")
+        check_button.setIcon(QIcon.fromTheme("list-add"))
+        policy = QSizePolicy()
+        policy.ShrinkFlag = True
+        check_button.setSizePolicy(policy)
+        check_button.clicked.connect(self.check_in_identifiers_org)
+        l3.addWidget(check_button)
+
+        l.addItem(l3)
+
         l2 = QHBoxLayout()
         self.annotation = QTableWidget(0, 2)
         self.annotation.setHorizontalHeaderLabels(
@@ -317,6 +332,57 @@ class MetabolitesMask(QWidget):
             else:
                 turn_white(self.id)
                 return True
+
+    def check_in_identifiers_org(self):
+        rows = self.annotation.rowCount()
+        valid_green = QColor(0, 255, 0)
+        invalid_red = QColor(255, 0, 0)
+        for i in range(0, rows):
+            if self.annotation.item(i, 0) is not None:
+                key = self.annotation.item(i, 0).text()
+            else:
+                key = ""
+            if self.annotation.item(i, 1) is not None:
+                values = self.annotation.item(i, 1).text()
+            else:
+                values = ""
+            if (key == "") or (values == ""):
+                continue
+
+            if values.startswith("["):
+                values = values.replace("', ", "'\b,").replace('", ', '"\b,').replace("[", "")\
+                               .replace("]", "").replace("'", "").replace('"', "")
+                values = values.split("\b,")
+            else:
+                values = [values]
+
+            for value in values:
+                is_valid, connection_error = check_identifiers_org_entry(key, value)
+
+                if connection_error:
+                    msgBox = QMessageBox()
+                    msgBox.setWindowTitle("Connection error!")
+                    msgBox.setTextFormat(Qt.RichText)
+                    msgBox.setText("<p>identifiers.org could not be accessed. Either the internet connection isn't working or the server is currently down.</p>")
+                    msgBox.setIcon(QMessageBox.Warning)
+                    msgBox.exec()
+                    break
+
+                if (not is_valid) and (":" in value):
+                    split_value = value.split(":")
+                    is_valid, connection_error = check_identifiers_org_entry(split_value[0], split_value[1])
+
+
+                if is_valid:
+                    color = valid_green
+                else:
+                    color = invalid_red
+
+                self.annotation.item(i, 0).setBackground(color)
+                self.annotation.item(i, 1).setBackground(color)
+
+                if not is_valid:
+                    break
 
     def validate_name(self):
         with self.appdata.project.cobra_py_model as model:

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -336,7 +336,6 @@ class MetabolitesMask(QWidget):
     def check_in_identifiers_org(self):
         self.setCursor(Qt.BusyCursor)
         rows = self.annotation.rowCount()
-        valid_green = QColor(0, 255, 0)
         invalid_red = QColor(255, 0, 0)
         for i in range(0, rows):
             if self.annotation.item(i, 0) is not None:
@@ -374,15 +373,11 @@ class MetabolitesMask(QWidget):
                     identifiers_org_result = check_identifiers_org_entry(split_value[0], split_value[1])
 
 
-                if identifiers_org_result.is_key_valid:
-                    key_color = valid_green
-                else:
+                if not identifiers_org_result.is_key_valid:
                     key_color = invalid_red
                 self.annotation.item(i, 0).setBackground(key_color)
 
-                if identifiers_org_result.is_key_value_pair_valid:
-                    value_color = valid_green
-                else:
+                if not identifiers_org_result.is_key_value_pair_valid:
                     value_color = invalid_red
                 self.annotation.item(i, 1).setBackground(value_color)
 

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -538,6 +538,7 @@ class ReactionMask(QWidget):
             self.reactionChanged.emit(self.reaction)
 
     def check_in_identifiers_org(self):
+        self.setCursor(Qt.BusyCursor)
         rows = self.annotation.rowCount()
         valid_green = QColor(0, 255, 0)
         invalid_red = QColor(255, 0, 0)
@@ -561,9 +562,9 @@ class ReactionMask(QWidget):
                 values = [values]
 
             for value in values:
-                is_valid, connection_error = check_identifiers_org_entry(key, value)
+                identifiers_org_result = check_identifiers_org_entry(key, value)
 
-                if connection_error:
+                if identifiers_org_result.connection_error:
                     msgBox = QMessageBox()
                     msgBox.setWindowTitle("Connection error!")
                     msgBox.setTextFormat(Qt.RichText)
@@ -572,20 +573,26 @@ class ReactionMask(QWidget):
                     msgBox.exec()
                     break
 
-                if (not is_valid) and (":" in value):
+                if (not identifiers_org_result.is_key_value_pair_valid) and (":" in value):
                     split_value = value.split(":")
-                    is_valid, connection_error = check_identifiers_org_entry(split_value[0], split_value[1])
+                    identifiers_org_result = check_identifiers_org_entry(split_value[0], split_value[1])
 
-                if is_valid:
-                    color = valid_green
+
+                if identifiers_org_result.is_key_valid:
+                    key_color = valid_green
                 else:
-                    color = invalid_red
+                    key_color = invalid_red
+                self.annotation.item(i, 0).setBackground(key_color)
 
-                self.annotation.item(i, 0).setBackground(color)
-                self.annotation.item(i, 1).setBackground(color)
+                if identifiers_org_result.is_key_value_pair_valid:
+                    value_color = valid_green
+                else:
+                    value_color = invalid_red
+                self.annotation.item(i, 1).setBackground(value_color)
 
-                if not is_valid:
+                if not identifiers_org_result.is_key_value_pair_valid:
                     break
+        self.setCursor(Qt.ArrowCursor)
 
     def delete_reaction(self):
         self.hide()

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -5,7 +5,7 @@ import traceback
 
 import cobra
 from qtpy.QtCore import QMimeData, Qt, Signal, Slot
-from qtpy.QtGui import QDrag, QIcon
+from qtpy.QtGui import QColor, QDrag, QIcon
 from qtpy.QtWidgets import (QHBoxLayout, QHeaderView, QLabel, QLineEdit,
                             QMessageBox, QPushButton, QSizePolicy, QSplitter,
                             QTableWidget, QTableWidgetItem, QTreeWidget,
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (QHBoxLayout, QHeaderView, QLabel, QLineEdit,
 
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white
+from cnapy.utils_for_cnapy_api import check_identifiers_org_entry
 
 
 class DragableTreeWidget(QTreeWidget):
@@ -434,8 +435,21 @@ class ReactionMask(QWidget):
         layout.addItem(l)
 
         l = QVBoxLayout()
+
+        l3 = QHBoxLayout()
         label = QLabel("Annotations:")
-        l.addWidget(label)
+        l3.addWidget(label)
+
+        check_button = QPushButton("identifiers.org check")
+        check_button.setIcon(QIcon.fromTheme("list-add"))
+        policy = QSizePolicy()
+        policy.ShrinkFlag = True
+        check_button.setSizePolicy(policy)
+        check_button.clicked.connect(self.check_in_identifiers_org)
+        l3.addWidget(check_button)
+
+        l.addItem(l3)
+
         l2 = QHBoxLayout()
         self.annotation = QTableWidget(0, 2)
         self.annotation.setHorizontalHeaderLabels(
@@ -522,6 +536,56 @@ class ReactionMask(QWidget):
 
             self.changed = False
             self.reactionChanged.emit(self.reaction)
+
+    def check_in_identifiers_org(self):
+        rows = self.annotation.rowCount()
+        valid_green = QColor(0, 255, 0)
+        invalid_red = QColor(255, 0, 0)
+        for i in range(0, rows):
+            if self.annotation.item(i, 0) is not None:
+                key = self.annotation.item(i, 0).text()
+            else:
+                key = ""
+            if self.annotation.item(i, 1) is not None:
+                values = self.annotation.item(i, 1).text()
+            else:
+                values = ""
+            if (key == "") or (values == ""):
+                continue
+
+            if values.startswith("["):
+                values = values.replace("', ", "'\b,").replace('", ', '"\b,').replace("[", "")\
+                               .replace("]", "").replace("'", "").replace('"', "")
+                values = values.split("\b,")
+            else:
+                values = [values]
+
+            for value in values:
+                is_valid, connection_error = check_identifiers_org_entry(key, value)
+
+                if connection_error:
+                    msgBox = QMessageBox()
+                    msgBox.setWindowTitle("Connection error!")
+                    msgBox.setTextFormat(Qt.RichText)
+                    msgBox.setText("<p>identifiers.org could not be accessed. Either the internet connection isn't working or the server is currently down.</p>")
+                    msgBox.setIcon(QMessageBox.Warning)
+                    msgBox.exec()
+                    break
+
+                if (not is_valid) and (":" in value):
+                    split_value = value.split(":")
+                    is_valid, connection_error = check_identifiers_org_entry(split_value[0], split_value[1])
+
+                if is_valid:
+                    color = valid_green
+                else:
+                    color = invalid_red
+
+                self.annotation.item(i, 0).setBackground(color)
+                self.annotation.item(i, 1).setBackground(color)
+
+                if not is_valid:
+                    break
 
     def delete_reaction(self):
         self.hide()

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -540,7 +540,6 @@ class ReactionMask(QWidget):
     def check_in_identifiers_org(self):
         self.setCursor(Qt.BusyCursor)
         rows = self.annotation.rowCount()
-        valid_green = QColor(0, 255, 0)
         invalid_red = QColor(255, 0, 0)
         for i in range(0, rows):
             if self.annotation.item(i, 0) is not None:
@@ -578,15 +577,11 @@ class ReactionMask(QWidget):
                     identifiers_org_result = check_identifiers_org_entry(split_value[0], split_value[1])
 
 
-                if identifiers_org_result.is_key_valid:
-                    key_color = valid_green
-                else:
+                if not identifiers_org_result.is_key_valid:
                     key_color = invalid_red
                 self.annotation.item(i, 0).setBackground(key_color)
 
-                if identifiers_org_result.is_key_value_pair_valid:
-                    value_color = valid_green
-                else:
+                if not identifiers_org_result.is_key_value_pair_valid:
                     value_color = invalid_red
                 self.annotation.item(i, 1).setBackground(value_color)
 

--- a/cnapy/utils_for_cnapy_api.py
+++ b/cnapy/utils_for_cnapy_api.py
@@ -1,18 +1,51 @@
 """Functions which will be later added to CNAPy's API"""
 import requests
+from dataclasses import dataclass
 from typing import Tuple
 
 
-def check_identifiers_org_entry(key: str, value: str) -> Tuple[bool, bool]:
-    url = f"https://resolver.api.identifiers.org/{key}:{value}"
+@dataclass()
+class IdentifiersOrgResult:
+    connection_error: bool
+    is_key_valid: bool
+    is_key_value_pair_valid :bool
+
+
+def check_identifiers_org_entry(key: str, value: str) -> IdentifiersOrgResult:
+    identifiers_org_result = IdentifiersOrgResult(
+        False,
+        False,
+        False,
+    )
+
+    # Check key
+    url_key_check = f"https://resolver.api.identifiers.org/{key}"
     try:
-        result_object = requests.get(url)
+        result_object = requests.get(url_key_check)
     except requests.exceptions.RequestException:
         print("HTTP error")
-        return (False, True)
+        identifiers_org_result.connection_error = True
+        return identifiers_org_result
     result_json = result_object.json()
 
     if result_json["errorMessage"] is None:
-        return (True, False)
+        identifiers_org_result.is_key_valid = True
+    else:
+        return identifiers_org_result
 
-    return (False, False)
+    # Check key:value pair
+    url_key_value_pair_check = f"https://resolver.api.identifiers.org/{key}:{value}"
+    try:
+        result_object = requests.get(url_key_value_pair_check)
+    except requests.exceptions.RequestException:
+        print("HTTP error")
+        identifiers_org_result.connection_error = True
+        return identifiers_org_result
+    result_json = result_object.json()
+
+    if result_json["errorMessage"] is None:
+        identifiers_org_result.is_key_value_pair_valid = True
+    else:
+        return identifiers_org_result
+
+    return identifiers_org_result

--- a/cnapy/utils_for_cnapy_api.py
+++ b/cnapy/utils_for_cnapy_api.py
@@ -1,0 +1,18 @@
+"""Functions which will be later added to CNAPy's API"""
+import requests
+from typing import Tuple
+
+
+def check_identifiers_org_entry(key: str, value: str) -> Tuple[bool, bool]:
+    url = f"https://resolver.api.identifiers.org/{key}:{value}"
+    try:
+        result_object = requests.get(url)
+    except requests.exceptions.RequestException:
+        print("HTTP error")
+        return (False, True)
+    result_json = result_object.json()
+
+    if result_json["errorMessage"] is None:
+        return (True, False)
+
+    return (False, False)

--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - appdirs
   - cobra=0.22
   - qtconsole=5.0
+  - requests
   - efmtool_link=0.0.3
   - optlang_enumerator=0.0.6
 prefix: /home/user/miniconda3/envs/cnapy

--- a/recipes/linux/meta.yaml
+++ b/recipes/linux/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - appdirs
     - cobra=0.22
     - qtconsole=5.0
+    - requests
     - efmtool_link=0.0.3
     - optlang_enumerator=0.0.6
 

--- a/recipes/noarch/meta.yaml
+++ b/recipes/noarch/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - appdirs
     - cobra=0.22
     - qtconsole=5.0
+    - requests
     - efmtool_link=0.0.3
     - optlang_enumerator=0.0.6
 

--- a/recipes/win/meta.yaml
+++ b/recipes/win/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - appdirs
     - cobra=0.22
     - qtconsole=5.0
+    - requests
     - efmtool_link=0.0.3
     - optlang_enumerator=0.0.6
 


### PR DESCRIPTION
In the spirit of (but not solving) #324, the changes include the following:
* A function which includes an identifiers.org check for a given annotation
* An annotation turns green if it can be found in identifiers.org (either via a key:value pair, *or*, if the value is a stringified list, for each of the values, *or*, if the value includes a ":" (such as in "SBO:00001"), the value.split(":")[0]:value.split(":")[1] pair is used) , and otherwise (if at least one value is invalid) red.

Implementation note: Since the annotation table is not its own widget type currently, I had to double the validation reaction for the metabolites nd the reaction annotation list. In the future, it would be better to bring the functionalities of the tables together.