### PR TITLE
New CNA project download logic

### DIFF
--- a/cnapy/gui_elements/download_dialog.py
+++ b/cnapy/gui_elements/download_dialog.py
@@ -1,9 +1,8 @@
 """The CNApy download examples files dialog"""
 import os
-import shutil
 import urllib.request
+from zipfile import ZipFile
 
-import pkg_resources
 from qtpy.QtWidgets import (
     QLabel, QDialog, QHBoxLayout, QPushButton,  QVBoxLayout)
 
@@ -46,24 +45,17 @@ class DownloadDialog(QDialog):
         print("Create work directory:", work_directory)
         os.mkdir(work_directory)
 
-        targets = ["ECC2.cna", "ECC2comp.cna", "e_coli_core.cna", "SmallExample.cna",
-                   "iJO1366.cna", "iJO1366core.cna", "iML1515.cna", "iML1515core.cna"]
+        targets = ["all_cnapy_projects.zip"]
         for t in targets:
             target = os.path.join(work_directory, t)
             if not os.path.exists(target):
-                print("Download:", target)
-                url = 'https://github.com/cnapy-org/CNApy-projects/releases/download/0.0.4/'+t
+                print("Downloading ", target, "...")
+                url = 'https://github.com/cnapy-org/CNApy-projects/releases/download/0.0.5/' + t
                 urllib.request.urlretrieve(url, target)
 
-        scen_file = pkg_resources.resource_filename(
-            'cnapy', 'data/Ecoli-glucose-standard.scen')
-        target = os.path.join(
-            work_directory, 'Ecoli-glucose-standard.scen')
-        shutil.copyfile(scen_file, target)
-        scen_file = pkg_resources.resource_filename(
-            'cnapy', 'data/Ecoli-flux-analysis.scen')
-        target = os.path.join(
-            work_directory, 'Ecoli-flux-analysis.scen')
-        shutil.copyfile(scen_file, target)
+                zip_path = os.path.join(work_directory, t)
+                with ZipFile(zip_path, 'r') as zip_file:
+                    zip_file.extractall()
+                os.remove(zip_path)
 
         self.accept()

--- a/cnapy/gui_elements/download_dialog.py
+++ b/cnapy/gui_elements/download_dialog.py
@@ -14,17 +14,17 @@ class DownloadDialog(QDialog):
 
     def __init__(self, appdata: AppData):
         QDialog.__init__(self)
-        self.setWindowTitle("Create folder with example files?")
+        self.setWindowTitle("Create folder with example projects?")
 
         self.appdata = appdata
         self.layout = QVBoxLayout()
 
         label_line = QVBoxLayout()
         label = QLabel(
-            "CNApy has found no projects directory.")
+            "CNApy could not find a projects directory.")
         label_line.addWidget(label)
         label = QLabel(
-            "Should CNApy create a projects directory and download examples files?")
+            "Should CNApy create a projects directory and download example projects?")
         label_line.addWidget(label)
         self.layout.addItem(label_line)
 


### PR DESCRIPTION
I changed the example projects download logic towards the suggested new way of releasing projects via .zip files. Right now, the big .zip file is downloaded (although later on, specific files can be mentioned if this .zip files gets too big) and extracted. After the extraction, the .zip file is deleted.