### PR TITLE
Add CNA configuration problem workaround

### DIFF
--- a/cnapy/gui_elements/mcs_dialog.py
+++ b/cnapy/gui_elements/mcs_dialog.py
@@ -203,6 +203,8 @@ class MCSDialog(QDialog):
             deactivate_external_solvers = True
 
         if not deactivate_external_solvers:
+            # The following try-except block is added as a workaround as long as the
+            # current CNA version cannot be directly read.
             try:
                 self.solver_cplex_matlab.setEnabled(
                     self.eng.is_cplex_matlab_ready())

--- a/cnapy/gui_elements/mcs_dialog.py
+++ b/cnapy/gui_elements/mcs_dialog.py
@@ -198,16 +198,35 @@ class MCSDialog(QDialog):
 
         # Disable incompatible combinations
         self.solver_optlang.setChecked(True)
+        deactivate_external_solvers = False
         if (appdata.selected_engine == 'None') or (self.eng is None) or (not appdata.cna_ok):  # Hotfix
+            deactivate_external_solvers = True
+
+        if not deactivate_external_solvers:
+            try:
+                self.solver_cplex_matlab.setEnabled(
+                    self.eng.is_cplex_matlab_ready())
+                self.solver_cplex_java.setEnabled(self.eng.is_cplex_java_ready())
+                self.solver_intlinprog.setEnabled(self.appdata.is_matlab_set())
+            except Exception:  # Either a Matlab or an Octave error due to a wrong configuration of CellNetAnalyzer
+                msgBox = QMessageBox()
+                msgBox.setWindowTitle("CellNetAnalyzer error!")
+                msgBox.setTextFormat(Qt.RichText)
+                msgBox.setText("<p>Error when loading CellNetAnalyzer. MCS calculation only possible with cobrapy solvers.<br>"
+                               "This error may be resolved in one of the following ways:<br>"
+                               "1. Check that you have the latest CellNetAnalyzer version and that you have set in in CNApy's configuration correctly.<br>"
+                               "2. If CellNetAnalyzer is up-to-date and correctly set in CNApy and this error still occurs, check that you can successfully run CellNetAnalyzer using MATLAB or Octave. "
+                               "</p>")
+                msgBox.setIcon(QMessageBox.Warning)
+                msgBox.exec()
+                deactivate_external_solvers = True
+
+        if deactivate_external_solvers:
             self.solver_cplex_matlab.setEnabled(False)
             self.solver_cplex_java.setEnabled(False)
             self.solver_glpk.setEnabled(False)
             self.solver_intlinprog.setEnabled(False)
-        else:
-            self.solver_cplex_matlab.setEnabled(
-                self.eng.is_cplex_matlab_ready())
-            self.solver_cplex_java.setEnabled(self.eng.is_cplex_java_ready())
-            self.solver_intlinprog.setEnabled(self.appdata.is_matlab_set())
+
         self.configure_solver_options()
 
         s4 = QVBoxLayout()

--- a/cnapy/gui_elements/yield_optimization_dialog.py
+++ b/cnapy/gui_elements/yield_optimization_dialog.py
@@ -132,6 +132,8 @@ class YieldOptimizationDialog(QDialog):
             # create CobraModel for matlab
             self.appdata.create_cobra_model()
 
+            # The following try-except block is added as a workaround as long as the
+            # current CNA version cannot be directly read.
             try:
                 self.eng.eval("load('cobra_model.mat')",
                             nargout=0)

--- a/cnapy/gui_elements/yield_optimization_dialog.py
+++ b/cnapy/gui_elements/yield_optimization_dialog.py
@@ -132,10 +132,24 @@ class YieldOptimizationDialog(QDialog):
             # create CobraModel for matlab
             self.appdata.create_cobra_model()
 
-            self.eng.eval("load('cobra_model.mat')",
-                          nargout=0)
-            self.eng.eval("cnap = CNAcobra2cna(cbmodel);",
-                          nargout=0)
+            try:
+                self.eng.eval("load('cobra_model.mat')",
+                            nargout=0)
+                self.eng.eval("cnap = CNAcobra2cna(cbmodel);",
+                            nargout=0)
+            except Exception:  # Either a Matlab or an Octave error due to a wrong configuration of CellNetAnalyzer
+                msgBox = QMessageBox()
+                msgBox.setWindowTitle("CellNetAnalyzer error!")
+                msgBox.setTextFormat(Qt.RichText)
+                msgBox.setText("<p>Error when loading CellNetAnalyzer. Yield calculation not possible!<br>"
+                               "This error may be resolved in one of the following ways:<br>"
+                               "1. Check that you have the latest CellNetAnalyzer version and that you have set in in CNApy's configuration correctly.<br>"
+                               "2. If CellNetAnalyzer is up-to-date and correctly set in CNApy and this error still occurs, check that you can successfully run CellNetAnalyzer using MATLAB or Octave. "
+                               "</p>")
+                msgBox.setIcon(QMessageBox.Warning)
+                msgBox.exec()
+                self.setCursor(Qt.ArrowCursor)
+                return
 
             # get some data
             self.eng.eval("reac_id = cellstr(cnap.reacID)';",


### PR DESCRIPTION
This workaround displays pop-up windows with potential error-solving instructions in the case that CellNetAnalyzer is not correctly configured.