### PR TITLE
Update octave_engine.py

### DIFF
--- a/cnapy/octave_engine.py
+++ b/cnapy/octave_engine.py
@@ -1,14 +1,15 @@
 import tempfile
 import os
 import re
-
+from platform import system
 from pkg_resources import VersionConflict
 
 try:
-    octave_version = re.search(r'(?<=version).*?(?=\n|$|\.)',os.popen("octave -v").read())
-    octave_version = int(octave_version.group(0))
-    if octave_version <= 4:
-        raise VersionConflict()
+    if system() == "Linux":
+        octave_version = re.search(r'(?<=version).*?(?=\n|$|\.)',os.popen("octave -v").read())
+        octave_version = int(octave_version.group(0))
+        if octave_version <= 4:
+            raise VersionConflict()
     
     from oct2py import Oct2Py # calls Oct2Py() in __init__ which creates a temporary directory that is not deleted
     from oct2py.utils import Oct2PyError

--- a/cnapy/octave_engine.py
+++ b/cnapy/octave_engine.py
@@ -1,6 +1,15 @@
 import tempfile
+import os
+import re
+
+from pkg_resources import VersionConflict
 
 try:
+    octave_version = re.search(r'(?<=version).*?(?=\n|$|\.)',os.popen("octave -v").read())
+    octave_version = int(octave_version.group(0))
+    if octave_version <= 4:
+        raise VersionConflict()
+    
     from oct2py import Oct2Py # calls Oct2Py() in __init__ which creates a temporary directory that is not deleted
     from oct2py.utils import Oct2PyError
 
@@ -36,5 +45,5 @@ try:
                 print("CNA not availabe ... continue with CNA disabled.")
                 return False
 
-except (ModuleNotFoundError, OSError):
+except: #(VersionConflict, OSError, EOFError):
     pass


### PR DESCRIPTION
On Linux systems, call the system's octave command to check version. If version is 4 or below, skip loading octave package.