### PR TITLE
Refactored reaction tree

### DIFF
--- a/cnapy/gui_elements/gene_list.py
+++ b/cnapy/gui_elements/gene_list.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import (QAction, QHBoxLayout, QLabel,
 
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white
-from cnapy.gui_elements.reaction_tree_widget import ModelElementType, ReactionTreeWidget
+from cnapy.gui_elements.reaction_table_widget import ModelElementType, ReactionTableWidget
 
 
 class GeneList(QWidget):
@@ -199,10 +199,11 @@ class GenesMask(QWidget):
         label = QLabel("Reactions using this gene:")
         l.addWidget(label)
         l2 = QHBoxLayout()
-        self.reactions = ReactionTreeWidget(self.appdata, ModelElementType.GENE)
+        self.reactions = ReactionTableWidget (self.appdata, ModelElementType.GENE)
         l2.addWidget(self.reactions)
         l.addItem(l2)
         self.reactions.itemDoubleClicked.connect(self.emit_jump_to_reaction)
+        self.reactions.jumpToMetabolite.connect(self.emit_jump_to_metabolite)
         layout.addItem(l)
 
         self.setLayout(layout)

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -487,26 +487,6 @@ class MetabolitesMask(QWidget):
             self.apply()
             self.reactions.update_state(self.id.text(), self.metabolite_list)
 
-    """
-    def update_state(self):
-        QApplication.setOverrideCursor(Qt.BusyCursor)
-        QApplication.processEvents() # to put the change above into effect
-        self.reactions.clearContents()
-        self.reactions.setRowCount(0) # also resets manually changed row heights
-        if self.appdata.project.cobra_py_model.metabolites.has_id(self.id.text()):
-            metabolite = self.appdata.project.cobra_py_model.metabolites.get_by_id(
-                self.id.text())
-            self.reactions.setSortingEnabled(False)
-            self.reactions.setRowCount(len(metabolite.reactions))
-            for i, reaction in enumerate(metabolite.reactions):
-                item = QTableWidgetItem(reaction.id)
-                self.reactions.setItem(i, 0, item)
-                reaction_string_widget = ReactionString(reaction, self.metabolite_list)
-                self.reactions.setCellWidget(i, 1, reaction_string_widget)
-            self.reactions.setSortingEnabled(True)
-        QApplication.restoreOverrideCursor()
-    """
-
     @Slot(QTableWidgetItem)
     def emit_jump_to_reaction(self, item: QTableWidgetItem):
         self.jumpToReaction.emit(item.text())

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel, QPlainTex
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white
 from cnapy.utils_for_cnapy_api import check_identifiers_org_entry
-from cnapy.gui_elements.reaction_tree_widget import ModelElementType, ReactionTreeWidget
+from cnapy.gui_elements.reaction_table_widget import ModelElementType, ReactionTableWidget
 
 
 class MetaboliteList(QWidget):
@@ -266,7 +266,7 @@ class MetabolitesMask(QWidget):
         label = QLabel("Reactions using this metabolite:")
         l.addWidget(label)
         l2 = QHBoxLayout()
-        self.reactions = ReactionTreeWidget(self.appdata, ModelElementType.METABOLITE)
+        self.reactions = ReactionTableWidget (self.appdata, ModelElementType.METABOLITE)
         l2.addWidget(self.reactions)
         l.addItem(l2)
         self.reactions.itemDoubleClicked.connect(self.emit_jump_to_reaction)

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -3,10 +3,10 @@
 import cobra
 from qtpy.QtCore import Qt, Signal, Slot
 from qtpy.QtGui import QColor, QIcon
-from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel, QPlainTextEdit,
+from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel,
                             QLineEdit, QMenu, QMessageBox, QPushButton, QSizePolicy,
-                            QSplitter, QTableWidget, QTableWidgetItem, QAbstractItemView,
-                            QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget, QApplication)
+                            QSplitter, QTableWidget, QTableWidgetItem,
+                            QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel, QPlainTex
 from cnapy.appdata import AppData
 from cnapy.utils import SignalThrottler, turn_red, turn_white
 from cnapy.utils_for_cnapy_api import check_identifiers_org_entry
+from cnapy.gui_elements.reaction_tree_widget import ModelElementType, ReactionTreeWidget
 
 
 class MetaboliteList(QWidget):
@@ -143,7 +144,7 @@ class MetaboliteList(QWidget):
             turn_white(self.metabolite_mask.charge)
             turn_white(self.metabolite_mask.compartment)
             self.metabolite_mask.is_valid = True
-            self.metabolite_mask.update_state()
+            self.metabolite_mask.reactions.update_state(self.metabolite_mask.id.text(), self.metabolite_mask.metabolite_list)
 
     def update(self):
         self.metabolite_list.clear()
@@ -265,11 +266,7 @@ class MetabolitesMask(QWidget):
         label = QLabel("Reactions using this metabolite:")
         l.addWidget(label)
         l2 = QHBoxLayout()
-        self.reactions = QTableWidget()
-        self.reactions.setColumnCount(2)
-        self.reactions.setHorizontalHeaderLabels(["Id", "Reaction"])
-        self.reactions.horizontalHeader().setStretchLastSection(True)
-        self.reactions.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
+        self.reactions = ReactionTreeWidget(self.appdata, ModelElementType.METABOLITE)
         l2.addWidget(self.reactions)
         l.addItem(l2)
         self.reactions.itemDoubleClicked.connect(self.emit_jump_to_reaction)
@@ -488,8 +485,9 @@ class MetabolitesMask(QWidget):
         self.validate_mask()
         if self.is_valid:
             self.apply()
-            self.update_state()
+            self.reactions.update_state(self.id.text(), self.metabolite_list)
 
+    """
     def update_state(self):
         QApplication.setOverrideCursor(Qt.BusyCursor)
         QApplication.processEvents() # to put the change above into effect
@@ -507,6 +505,7 @@ class MetabolitesMask(QWidget):
                 self.reactions.setCellWidget(i, 1, reaction_string_widget)
             self.reactions.setSortingEnabled(True)
         QApplication.restoreOverrideCursor()
+    """
 
     @Slot(QTableWidgetItem)
     def emit_jump_to_reaction(self, item: QTableWidgetItem):
@@ -515,19 +514,3 @@ class MetabolitesMask(QWidget):
     jumpToReaction = Signal(str)
     metaboliteChanged = Signal(cobra.Metabolite, object)
     metaboliteDeleted = Signal(cobra.Metabolite, object)
-
-
-class ReactionString(QPlainTextEdit):
-    def __init__(self, reaction, metabolite_list):
-        super().__init__()
-        self.setPlainText(reaction.build_reaction_string())
-        self.setReadOnly(True)
-        self.model = reaction.model
-        self.metabolite_list = metabolite_list
-        self.selectionChanged.connect(self.switch_metabolite)
-
-    @Slot()
-    def switch_metabolite(self):
-        selected_text = self.textCursor().selectedText()
-        if self.model.metabolites.has_id(selected_text):
-            self.metabolite_list.set_current_item(selected_text)

--- a/cnapy/gui_elements/reaction_table_widget.py
+++ b/cnapy/gui_elements/reaction_table_widget.py
@@ -23,12 +23,11 @@ class ReactionString(QPlainTextEdit):
     def switch_metabolite(self):
         selected_text = self.textCursor().selectedText()
         if self.model.metabolites.has_id(selected_text):
-            print("L", selected_text)
             self.jumpToMetabolite.emit(selected_text)
             self.metabolite_list.set_current_item(selected_text)
 
 
-class ReactionTreeWidget(QTableWidget):
+class ReactionTableWidget(QTableWidget):
     def __init__(self, appdata, element_type: ModelElementType) -> None:
         super().__init__()
 
@@ -60,6 +59,11 @@ class ReactionTreeWidget(QTableWidget):
                 item = QTableWidgetItem(reaction.id)
                 self.setItem(i, 0, item)
                 reaction_string_widget = ReactionString(reaction, metabolite_list)
+                reaction_string_widget.jumpToMetabolite.connect(self.emit_jump_to_metabolite)
                 self.setCellWidget(i, 1, reaction_string_widget)
             self.setSortingEnabled(True)
         QApplication.restoreOverrideCursor()
+
+    jumpToMetabolite = Signal(str)
+    def emit_jump_to_metabolite(self, metabolite):
+        self.jumpToMetabolite.emit(metabolite)

--- a/cnapy/gui_elements/reaction_tree_widget.py
+++ b/cnapy/gui_elements/reaction_tree_widget.py
@@ -9,19 +9,23 @@ class ModelElementType(Enum):
 
 
 class ReactionString(QPlainTextEdit):
-    def __init__(self, reaction, metabolite_or_gene_list):
+    def __init__(self, reaction, metabolite_list):
         super().__init__()
         self.setPlainText(reaction.build_reaction_string())
         self.setReadOnly(True)
         self.model = reaction.model
-        self.metabolite_or_gene_list = metabolite_or_gene_list
+        self.metabolite_list = metabolite_list
         self.selectionChanged.connect(self.switch_metabolite)
+
+    jumpToMetabolite = Signal(str)
 
     @Slot()
     def switch_metabolite(self):
         selected_text = self.textCursor().selectedText()
         if self.model.metabolites.has_id(selected_text):
-            self.metabolite_or_gene_list.set_current_item(selected_text)
+            print("L", selected_text)
+            self.jumpToMetabolite.emit(selected_text)
+            self.metabolite_list.set_current_item(selected_text)
 
 
 class ReactionTreeWidget(QTableWidget):
@@ -35,7 +39,7 @@ class ReactionTreeWidget(QTableWidget):
         self.horizontalHeader().setStretchLastSection(True)
         self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
 
-    def update_state(self, id_text, metabolite_or_gene_list):
+    def update_state(self, id_text, metabolite_list):
         QApplication.setOverrideCursor(Qt.BusyCursor)
         QApplication.processEvents() # to put the change above into effect
         self.clearContents()
@@ -55,7 +59,7 @@ class ReactionTreeWidget(QTableWidget):
             for i, reaction in enumerate(metabolite_or_gene.reactions):
                 item = QTableWidgetItem(reaction.id)
                 self.setItem(i, 0, item)
-                reaction_string_widget = ReactionString(reaction, metabolite_or_gene_list)
+                reaction_string_widget = ReactionString(reaction, metabolite_list)
                 self.setCellWidget(i, 1, reaction_string_widget)
             self.setSortingEnabled(True)
         QApplication.restoreOverrideCursor()

--- a/cnapy/gui_elements/reaction_tree_widget.py
+++ b/cnapy/gui_elements/reaction_tree_widget.py
@@ -1,0 +1,61 @@
+from enum import Enum
+from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtWidgets import QApplication, QTableWidget, QTableWidgetItem, QAbstractItemView, QPlainTextEdit
+
+
+class ModelElementType(Enum):
+    METABOLITE = 1
+    GENE = 2
+
+
+class ReactionString(QPlainTextEdit):
+    def __init__(self, reaction, metabolite_or_gene_list):
+        super().__init__()
+        self.setPlainText(reaction.build_reaction_string())
+        self.setReadOnly(True)
+        self.model = reaction.model
+        self.metabolite_or_gene_list = metabolite_or_gene_list
+        self.selectionChanged.connect(self.switch_metabolite)
+
+    @Slot()
+    def switch_metabolite(self):
+        selected_text = self.textCursor().selectedText()
+        if self.model.metabolites.has_id(selected_text):
+            self.metabolite_or_gene_list.set_current_item(selected_text)
+
+
+class ReactionTreeWidget(QTableWidget):
+    def __init__(self, appdata, element_type: ModelElementType) -> None:
+        super().__init__()
+
+        self.appdata = appdata
+        self.element_type = element_type
+        self.setColumnCount(2)
+        self.setHorizontalHeaderLabels(["Id", "Reaction"])
+        self.horizontalHeader().setStretchLastSection(True)
+        self.setHorizontalScrollMode(QAbstractItemView.ScrollPerPixel)
+
+    def update_state(self, id_text, metabolite_or_gene_list):
+        QApplication.setOverrideCursor(Qt.BusyCursor)
+        QApplication.processEvents() # to put the change above into effect
+        self.clearContents()
+        self.setRowCount(0) # also resets manually changed row heights
+
+        if self.element_type is ModelElementType.METABOLITE:
+            model_elements = self.appdata.project.cobra_py_model.metabolites
+        elif self.element_type is ModelElementType.GENE:
+            model_elements = self.appdata.project.cobra_py_model.genes
+
+        if model_elements.has_id(id_text):
+            metabolite_or_gene = model_elements.get_by_id(
+                id_text
+            )
+            self.setSortingEnabled(False)
+            self.setRowCount(len(metabolite_or_gene.reactions))
+            for i, reaction in enumerate(metabolite_or_gene.reactions):
+                item = QTableWidgetItem(reaction.id)
+                self.setItem(i, 0, item)
+                reaction_string_widget = ReactionString(reaction, metabolite_or_gene_list)
+                self.setCellWidget(i, 1, reaction_string_widget)
+            self.setSortingEnabled(True)
+        QApplication.restoreOverrideCursor()


### PR DESCRIPTION
I just refactored the reaction tree of the metabolite mask into a separate class which is now also used by the genes list.
*Almost* everything works, except of swtching to a double-clicked metabolite in the genes list. I fiddled with the associated signals but could not make it work, so that help in solving this issue would be very appreciated :-)