### PR TITLE
Search for annotation values

### DIFF
--- a/cnapy/gui_elements/central_widget.py
+++ b/cnapy/gui_elements/central_widget.py
@@ -7,7 +7,7 @@ from qtconsole.inprocess import QtInProcessKernelManager
 from qtconsole.rich_jupyter_widget import RichJupyterWidget
 from qtpy.QtCore import Qt, Signal, Slot, QSignalBlocker
 from qtpy.QtGui import QColor, QBrush
-from qtpy.QtWidgets import (QDialog, QLabel, QLineEdit, QPushButton, QSplitter,
+from qtpy.QtWidgets import (QCheckBox, QDialog, QHBoxLayout, QLabel, QLineEdit, QPushButton, QSplitter,
                             QTabWidget, QVBoxLayout, QWidget, QAction)
 
 from cnapy.appdata import AppData, CnaMap, parse_scenario
@@ -36,13 +36,20 @@ class CentralWidget(QWidget):
         self.parent = parent
         self.appdata: AppData = parent.appdata
         self.map_counter = 0
+
+        searchbar_layout = QHBoxLayout()
         self.searchbar = QLineEdit()
         self.searchbar.setPlaceholderText("Enter search term")
         self.searchbar.setClearButtonEnabled(True)
+        searchbar_layout.addWidget(self.searchbar)
+        self.search_annotations = QCheckBox("+Annotations")
+        self.search_annotations.setChecked(False)
+        searchbar_layout.addWidget(self.search_annotations)
 
         self.throttler = SignalThrottler(300)
         self.searchbar.textChanged.connect(self.throttler.throttle)
         self.throttler.triggered.connect(self.update_selected)
+        self.search_annotations.clicked.connect(self.update_selected)
 
         self.tabs = QTabWidget()
         self.reaction_list = ReactionList(self)
@@ -97,7 +104,7 @@ class CentralWidget(QWidget):
         self.console.show()
 
         layout = QVBoxLayout()
-        layout.addWidget(self.searchbar)
+        layout.addItem(searchbar_layout)
         layout.addWidget(self.splitter)
         self.setLayout(layout)
         margins = self.layout().contentsMargins()
@@ -297,19 +304,25 @@ class CentralWidget(QWidget):
         diag.exec()
 
     def update_selected(self):
-        x = self.searchbar.text()
-        idx = self.tabs.currentIndex()
-        if idx == ModelTabIndex.Reactions:
-            self.reaction_list.update_selected(x)
-        if idx == ModelTabIndex.Metabolites:
-            self.metabolite_list.update_selected(x)
-        if idx == ModelTabIndex.Genes:
-            self.gene_list.update_selected(x)
+        string = self.searchbar.text()
 
+        if len(string) == 0:
+            return
+
+        idx = self.tabs.currentIndex()
+        with_annotations = self.search_annotations.isChecked()
+        if idx == ModelTabIndex.Reactions:
+            found_ids = self.reaction_list.update_selected(string, with_annotations)
+        if idx == ModelTabIndex.Metabolites:
+            found_ids =self.metabolite_list.update_selected(string, with_annotations)
+        if idx == ModelTabIndex.Genes:
+            found_ids =self.gene_list.update_selected(string, with_annotations)
+
+        print(found_ids)
         idx = self.map_tabs.currentIndex()
         if idx >= 0:
             m = self.map_tabs.widget(idx)
-            m.update_selected(x)
+            m.update_selected(found_ids)
 
     def update_mode(self):
         if self.mode_navigator.mode_type <= 1:

--- a/cnapy/gui_elements/central_widget.py
+++ b/cnapy/gui_elements/central_widget.py
@@ -318,7 +318,6 @@ class CentralWidget(QWidget):
         if idx == ModelTabIndex.Genes:
             found_ids =self.gene_list.update_selected(string, with_annotations)
 
-        print(found_ids)
         idx = self.map_tabs.currentIndex()
         if idx >= 0:
             m = self.map_tabs.widget(idx)

--- a/cnapy/gui_elements/central_widget.py
+++ b/cnapy/gui_elements/central_widget.py
@@ -310,7 +310,7 @@ class CentralWidget(QWidget):
             return
 
         idx = self.tabs.currentIndex()
-        with_annotations = self.search_annotations.isChecked()
+        with_annotations = self.search_annotations.isChecked() and self.search_annotations.isEnabled()
         if idx == ModelTabIndex.Reactions:
             found_ids = self.reaction_list.update_selected(string, with_annotations)
         if idx == ModelTabIndex.Metabolites:

--- a/cnapy/gui_elements/escher_map_view.py
+++ b/cnapy/gui_elements/escher_map_view.py
@@ -93,7 +93,7 @@ class EscherMapView(QWebEngineView):
             tooltip = "['object','label']"
             menu = "none"
         self.page().runJavaScript("builder.settings.set('enable_editing',"+enable_str+
-            ");builder.settings.set('enable_keys',"+enable_str+ 
+            ");builder.settings.set('enable_keys',"+enable_str+
             ");builder.settings.set('enable_tooltips',"+tooltip+
             ");document.getElementsByClassName('button-panel')[0].hidden="+not_enable_str+
             ";document.getElementsByClassName('menu-bar')[0].style['display']='"+menu+"'")
@@ -162,13 +162,14 @@ class EscherMapView(QWebEngineView):
         # highlights and focuses on the first reatcion with reac_id
         self.page().runJavaScript("highlightAndFocusReaction('"+reac_id+"')")
 
-    def update_selected(self, find: str):
+    def update_selected(self, found_ids):
+        find = found_ids[0]  # Only search for the search string as Escher does not seem to be to search multiple different IDs
         if len(find) == 0:
             self.page().runJavaScript("search_container.style.display='none'")
         else:
             self.page().runJavaScript("search_container.style.display='';search_field.value='"+find+
                                       "';search_field.dispatchEvent(new Event('input'))")
-    
+
     def dragEnterEvent(self, event):
         event.ignore()
 

--- a/cnapy/gui_elements/gene_list.py
+++ b/cnapy/gui_elements/gene_list.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import (QAction, QHBoxLayout, QLabel,
                             QTableWidgetItem, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget)
 
 from cnapy.appdata import AppData
-from cnapy.utils import SignalThrottler, turn_red, turn_white
+from cnapy.utils import SignalThrottler, turn_red, turn_white, update_selected
 from cnapy.gui_elements.annotation_widget import AnnotationWidget
 from cnapy.gui_elements.reaction_table_widget import ModelElementType, ReactionTableWidget
 
@@ -96,17 +96,13 @@ class GeneList(QWidget):
         self.last_selected = self.gene_mask.id.text()
         self.geneChanged.emit(old_id, gene)
 
-    def update_selected(self, string):
-        root = self.gene_list.invisibleRootItem()
-        child_count = root.childCount()
-        for i in range(child_count):
-            item = root.child(i)
-            item.setHidden(True)
-
-        for item in self.gene_list.findItems(string, Qt.MatchContains, 0):
-            item.setHidden(False)
-        for item in self.gene_list.findItems(string, Qt.MatchContains, 1):
-            item.setHidden(False)
+    def update_selected(self, string, with_annotations):
+        return update_selected(
+            string=string,
+            with_annotations=with_annotations,
+            model_elements=self.appdata.project.cobra_py_model.genes,
+            element_list=self.gene_list,
+        )
 
     def gene_selected(self, item, _column):
         if item is None:

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -62,8 +62,8 @@ class MainWindow(QMainWindow):
         self.onoff_action = QAction("On/Off coloring", self)
         self.onoff_action.setIcon(QIcon(":/icons/onoff.png"))
         self.onoff_action.triggered.connect(self.set_onoff)
-        central_widget = CentralWidget(self)
-        self.setCentralWidget(central_widget)
+        self.central_widget = CentralWidget(self)
+        self.setCentralWidget(self.central_widget)
 
         self.menu = self.menuBar()
         self.file_menu = self.menu.addMenu("&Project")
@@ -181,7 +181,7 @@ class MainWindow(QMainWindow):
 
         update_action = QAction("Default Coloring", self)
         update_action.setIcon(QIcon(":/icons/default-color.png"))
-        update_action.triggered.connect(central_widget.update)
+        update_action.triggered.connect(self.central_widget.update)
 
         self.scenario_menu.addAction(self.heaton_action)
         self.scenario_menu.addAction(self.onoff_action)
@@ -215,7 +215,7 @@ class MainWindow(QMainWindow):
 
         add_map_action = QAction("Add new map", self)
         self.map_menu.addAction(add_map_action)
-        add_map_action.triggered.connect(central_widget.add_map)
+        add_map_action.triggered.connect(self.central_widget.add_map)
 
         add_escher_map_action = QAction("Add new map from Escher SVG...", self)
         self.map_menu.addAction(add_escher_map_action)
@@ -223,7 +223,7 @@ class MainWindow(QMainWindow):
 
         open_escher = QAction("Add interactive Escher map", self)
         self.map_menu.addAction(open_escher)
-        open_escher.triggered.connect(lambda: central_widget.add_map(escher=True))
+        open_escher.triggered.connect(lambda: self.central_widget.add_map(escher=True))
 
         self.change_map_name_action = QAction("Change map name", self)
         self.map_menu.addAction(self.change_map_name_action)
@@ -1313,10 +1313,12 @@ class MainWindow(QMainWindow):
                 self.escher_map_actions.setVisible(False)
                 self.cnapy_map_actions.setVisible(True)
                 self.colorings.setEnabled(True)
+                self.central_widget.search_annotations.setEnabled(True)
             else: # EscherMapView
                 self.cnapy_map_actions.setVisible(False)
                 self.escher_map_actions.setVisible(True)
                 self.colorings.setEnabled(False)
+                self.central_widget.search_annotations.setEnabled(False)
         else:
             self.change_map_name_action.setEnabled(False)
             self.change_background_action.setEnabled(False)

--- a/cnapy/gui_elements/map_view.py
+++ b/cnapy/gui_elements/map_view.py
@@ -202,15 +202,16 @@ class MapView(QGraphicsView):
         super().leaveEvent(event)
         self.clearFocus() # finishes editing of potentially active ReactionBox
 
-    def update_selected(self, string):
+    def update_selected(self, found_ids):
 
         for r_id, box in self.reaction_boxes.items():
-            if string.lower() in r_id.lower():
-                box.item.setHidden(False)
-            elif string.lower() in box.name.lower():
-                box.item.setHidden(False)
-            else:
-                box.item.setHidden(True)
+            box.item.setHidden(True)
+            for found_id in found_ids:
+                if found_id.lower() in r_id.lower():
+                    box.item.setHidden(False)
+                elif found_id.lower() in box.name.lower():
+                    box.item.setHidden(False)
+
 
     def focus_reaction(self, reaction: str):
         x = self.appdata.project.maps[self.name]["boxes"][reaction][0]

--- a/cnapy/gui_elements/metabolite_list.py
+++ b/cnapy/gui_elements/metabolite_list.py
@@ -10,7 +10,7 @@ from qtpy.QtWidgets import (QAction, QHBoxLayout, QHeaderView, QLabel,
 
 from cnapy.appdata import AppData
 from cnapy.gui_elements.annotation_widget import AnnotationWidget
-from cnapy.utils import SignalThrottler, turn_red, turn_white
+from cnapy.utils import SignalThrottler, turn_red, turn_white, update_selected
 from cnapy.utils_for_cnapy_api import check_identifiers_org_entry
 from cnapy.gui_elements.reaction_table_widget import ModelElementType, ReactionTableWidget
 
@@ -91,17 +91,13 @@ class MetaboliteList(QWidget):
         self.last_selected = self.metabolite_mask.id.text()
         self.metaboliteChanged.emit(metabolite, affected_reactions)
 
-    def update_selected(self, string):
-        root = self.metabolite_list.invisibleRootItem()
-        child_count = root.childCount()
-        for i in range(child_count):
-            item = root.child(i)
-            item.setHidden(True)
-
-        for item in self.metabolite_list.findItems(string, Qt.MatchContains, 0):
-            item.setHidden(False)
-        for item in self.metabolite_list.findItems(string, Qt.MatchContains, 1):
-            item.setHidden(False)
+    def update_selected(self, string, with_annotations=True):
+        return update_selected(
+            string=string,
+            with_annotations=with_annotations,
+            model_elements=self.appdata.project.cobra_py_model.metabolites,
+            element_list=self.metabolite_list,
+        )
 
     def metabolite_selected(self, item, _column):
         if item is None:

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import (QHBoxLayout, QHeaderView, QLabel, QLineEdit,
 
 from cnapy.appdata import AppData
 from cnapy.gui_elements.annotation_widget import AnnotationWidget
-from cnapy.utils import SignalThrottler, turn_red, turn_white
+from cnapy.utils import SignalThrottler, turn_red, turn_white, update_selected
 from cnapy.utils_for_cnapy_api import check_identifiers_org_entry, check_in_identifiers_org
 from cnapy.gui_elements.map_view import validate_value
 from cnapy.gui_elements.escher_map_view import EscherMapView
@@ -367,17 +367,13 @@ class ReactionList(QWidget):
             else:
                 item.setBackground(column, Qt.red)
 
-    def update_selected(self, string):
-        root = self.reaction_list.invisibleRootItem()
-        child_count = root.childCount()
-        for i in range(child_count):
-            item = root.child(i)
-            item.setHidden(True)
-
-        for item in self.reaction_list.findItems(string, Qt.MatchContains, 0):
-            item.setHidden(False)
-        for item in self.reaction_list.findItems(string, Qt.MatchContains, 1):
-            item.setHidden(False)
+    def update_selected(self, string, with_annotations):
+        return update_selected(
+            string=string,
+            with_annotations=with_annotations,
+            model_elements=self.appdata.project.cobra_py_model.reactions,
+            element_list=self.reaction_list,
+        )
 
     def update(self, rebuild=False):
         # should only need to rebuild the whole list if the model changes

--- a/cnapy/utils.py
+++ b/cnapy/utils.py
@@ -6,6 +6,33 @@ from straindesign import lineq2list, linexpr2dict
 import re
 
 
+def update_selected(string: str, with_annotations: bool, model_elements, element_list):
+    found_ids = [string]
+    if with_annotations:
+        for model_element in model_elements:
+            for key in model_element.annotation.keys():
+                annotations = model_element.annotation[key]
+                if type(annotations) is str:
+                    annotations = [annotations]
+                for annotation in annotations:
+                    if string.lower() in annotation.lower():
+                        found_ids.append(model_element.id)
+
+    root = element_list.invisibleRootItem()
+    child_count = root.childCount()
+    for i in range(child_count):
+        item = root.child(i)
+        item.setHidden(True)
+
+    for found_id in found_ids:
+        for item in element_list.findItems(found_id, Qt.MatchContains, 0):
+            item.setHidden(False)
+        for item in element_list.findItems(found_id, Qt.MatchContains, 1):
+            item.setHidden(False)
+
+    return found_ids
+
+
 def BORDER_COLOR(HEX):  # string that defines style sheet for changing the color of the module-box
     return "QGroupBox#EditModule " +\
         "{ border: 1px solid "+HEX+";" +\


### PR DESCRIPTION
Theses commits aim to fix #268. I refactored the search routine into one single function in utils.py, but maybe there's a better place (and type annotation) for it. Although many new for loops are introduced if one searches for annotation values, I don't have problems with the search speed up to now.
**At least one issue still remains**: In Escher, I didn't find a way to search for multiple completely different IDs as it might be the case with the annotation search. Up to now, only reactions which have a match with the search bar entry are highlighted but not all found reactions with a given annotation match.