### PR TITLE
Catch various error messages

### DIFF
--- a/cnapy/gui_elements/annotation_widget.py
+++ b/cnapy/gui_elements/annotation_widget.py
@@ -81,8 +81,11 @@ class AnnotationWidget(QVBoxLayout):
     def open_in_browser(self):
         current_row = self.annotation.currentRow()
         if current_row >= 0:
-            identifier_type = self.annotation.item(current_row, 0).text()
-            identifier_value = self.annotation.item(current_row, 1).text()
+            try:
+                identifier_type = self.annotation.item(current_row, 0).text()
+                identifier_value = self.annotation.item(current_row, 1).text()
+            except AttributeError:
+                pass
             if identifier_value.startswith("["):
                 identifier_value = ast.literal_eval(identifier_value)[0]
             url = f"https://identifiers.org/{identifier_type}:{identifier_value}"

--- a/cnapy/gui_elements/clipboard_calculator.py
+++ b/cnapy/gui_elements/clipboard_calculator.py
@@ -1,6 +1,6 @@
 """The cnapy clipboard calculator dialog"""
 from qtpy.QtWidgets import (QButtonGroup, QComboBox, QDialog, QHBoxLayout,
-                            QLineEdit, QPushButton, QRadioButton,
+                            QLineEdit, QMessageBox, QPushButton, QRadioButton,
                             QVBoxLayout)
 
 from cnapy.appdata import AppData
@@ -81,7 +81,15 @@ class ClipboardCalculator(QDialog):
         if self.l1.isChecked():
             l_comp = self.appdata.project.comp_values
         elif self.l2.isChecked():
-            l_comp = self.appdata.clipboard_comp_values
+            try:
+                l_comp = self.appdata.clipboard_comp_values
+            except AttributeError:
+                QMessageBox.warning(
+                    None,
+                    "No clipboard created yet",
+                    "Clipboard arithmetics do not work as no clipboard was created yet. Store values to a clipboard first to solve this problem."
+                )
+                return
 
         if self.r1.isChecked():
             r_comp = self.appdata.project.comp_values

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -1358,7 +1358,15 @@ class MainWindow(QMainWindow):
         self.appdata.clipboard_comp_values = self.appdata.project.comp_values.copy()
 
     def paste_clipboard(self):
-        self.appdata.project.comp_values = self.appdata.clipboard_comp_values.copy()
+        try:
+            self.appdata.project.comp_values = self.appdata.clipboard_comp_values.copy()
+        except AttributeError:
+            QMessageBox.warning(
+                self,
+                "No clipboard created yet",
+                "Paste clipboard does not work as no clipboard was created yet. Store values to a clipboard first to solve this problem."
+            )
+            return
         self.centralWidget().update()
 
     @Slot()

--- a/cnapy/gui_elements/plot_space_dialog.py
+++ b/cnapy/gui_elements/plot_space_dialog.py
@@ -2,7 +2,7 @@
 
 from random import randint
 from qtpy.QtCore import Qt, Signal, Slot, QTimer
-from qtpy.QtWidgets import (QDialog, QHBoxLayout, QLabel, QGroupBox, QComboBox, QLayout,
+from qtpy.QtWidgets import (QDialog, QHBoxLayout, QLabel, QMessageBox, QGroupBox, QComboBox, QLayout,
                             QPushButton, QVBoxLayout, QFrame, QCheckBox,QLineEdit, QSizePolicy)
 from cnapy.utils import QComplReceivLineEdit, QHSeperationLine
 from straindesign import linexpr2dict, linexprdict2str, yopt, avail_solvers, plot_flux_space
@@ -159,8 +159,15 @@ class PlotSpaceDialog(QDialog):
                     axes[2] = (self.z_numerator.text(),self.z_denominator.text())
                 else:
                     axes[2] = (self.z_numerator.text())
-            plot_flux_space(model,axes,points=int(self.numpoints.text()))
-
+            try:
+                plot_flux_space(model,axes,points=int(self.numpoints.text()))
+            except Exception as e:
+                QMessageBox.warning(
+                    self,
+                    "Error in plot calculation",
+                    "Plot space could not be calculated due to the following error:\n"
+                    f"{e}"
+                )
         self.appdata.window.centralWidget().show_bottom_of_console()
         self.setCursor(Qt.ArrowCursor)
 


### PR DESCRIPTION
In the quest to fix #89, I added (partly message box) catches for the following errors:
* An string-empty annotation key is being deleted
* A non-existing clipboard is being pasted or calculated on
* The plot space calculation fails due to a StrainDesign error