### PR TITLE
Add csv/xlsx flux results export

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - qtconsole=5.4
   - requests=2.28
   - psutil=5.9
+  - openpyxl
   - efmtool_link=0.0.4
   - optlang_enumerator=0.0.7
   - straindesign>=1.9


### PR DESCRIPTION
Here's my first take on exporting the current flux values (either FBA, FVA results or currently shown EFM values, ...) as comma-separated CSV or XLSX files. It utilizes pandas for it, although writing separate export functions would be trivial.

Maybe this also shows a way of how to export scenarios as Excel files.

And I wasn't sure where to put the functionality so that it resides in the Clipboard tab currently :3

**Note**: One has to install "openpyxl" via pip in order to make the XLSX export work.