### PR TITLE
Visual OptMDFpathway

### DIFF
--- a/cnapy/appdata.py
+++ b/cnapy/appdata.py
@@ -288,6 +288,7 @@ class ProjectData:
         self.comp_values_type = 0 # 0: simple flux vector, 1: bounds/FVA result
         self.fva_values: Dict[str, Tuple[float, float]] = {} # store FVA results persistently
         self.conc_values: Dict[str, float] = {} # Metabolite concentrations
+        self.df_values: Dict[str, float] = {} # Driving forces
         self.modes = []
         self.meta_data = {}
 

--- a/cnapy/appdata.py
+++ b/cnapy/appdata.py
@@ -287,6 +287,7 @@ class ProjectData:
         self.comp_values: Dict[str, Tuple[float, float]] = {}
         self.comp_values_type = 0 # 0: simple flux vector, 1: bounds/FVA result
         self.fva_values: Dict[str, Tuple[float, float]] = {} # store FVA results persistently
+        self.conc_values: Dict[str, float] = {} # Metabolite concentrations
         self.modes = []
         self.meta_data = {}
 

--- a/cnapy/core.py
+++ b/cnapy/core.py
@@ -135,4 +135,4 @@ def model_optimization_with_exceptions(model: cobra.Model):
                        "it under 'Config->Configure cobrapy'):\n"+error.message+\
                        "\nNOTE: Another error message will follow, you can safely ignore it.")
         msgBox.setIcon(QMessageBox.Warning)
-        msgBox.exec()
+        msgBox.show()

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -1930,7 +1930,7 @@ class MainWindow(QMainWindow):
             if cmin_in_cell is not None:
                 try:
                     cmin = float(cmin_in_cell)
-                except TypeError:
+                except ValueError:
                     warnings += f"WARNING: Cmin of {metabolite_id} could not be read as number. "\
                                 "This metabolite will be ignored.\n"
                     continue
@@ -1942,7 +1942,7 @@ class MainWindow(QMainWindow):
             if cmax_in_cell is not None:
                 try:
                     cmax = float(cmax_in_cell)
-                except TypeError:
+                except ValueError:
                     warnings += f"WARNING: Cmin of {metabolite_id} could not be read as number. "\
                                 "This metabolite will be ignored.\n"
                     continue
@@ -1990,7 +1990,7 @@ class MainWindow(QMainWindow):
             if dG0_in_cell is not None:
                 try:
                     dG0 = float(dG0_in_cell)
-                except TypeError:
+                except ValueError:
                     warnings += f"WARNING: dG'° of {reac_id} could not be read as number. "\
                                 "It will be ignored.\n"
                     continue
@@ -2001,7 +2001,7 @@ class MainWindow(QMainWindow):
                 if uncertainty_in_cell is not None:
                     try:
                         uncertainty = float(uncertainty_in_cell)
-                    except TypeError:
+                    except ValueError:
                         warnings += f"WARNING: Uncertainty of {reac_id} could not be read"\
                                     "as number. It will be ignored.\n"
                         continue

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -384,7 +384,7 @@ class MainWindow(QMainWindow):
         self.analysis_menu.addSeparator()
 
 
-        optmdf_action = QAction("Perform OptMDFpathway...", self)
+        optmdf_action = QAction("OptMDFpathway...", self)
         optmdf_action.triggered.connect(self.perform_optmdfpathway)
         self.analysis_menu.addAction(optmdf_action)
 

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -1050,6 +1050,8 @@ class MainWindow(QMainWindow):
         self.appdata.project.comp_values.clear()
         self.appdata.project.comp_values_type = 0
         self.appdata.project.fva_values.clear()
+        self.appdata.project.conc_values.clear()
+        self.appdata.project.df_values.clear()
         self.appdata.project.high = 0
         self.appdata.project.low = 0
         self.centralWidget().update()

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -1816,10 +1816,11 @@ class MainWindow(QMainWindow):
         self.solver_status_symbol.setStyleSheet("color: black")
         self.solver_status_symbol.setText("?")
 
+    @Slot()
     def perform_optmdfpathway(self):
         self.optmdfpathway_dialog = OptmdfpathwayDialog(
             self.appdata, self.centralWidget())
-        self.optmdfpathway_dialog.show()
+        self.optmdfpathway_dialog.exec_()
 
     def _load_json(self) -> Dict[Any, Any]:
         dialog = QFileDialog(self)

--- a/cnapy/gui_elements/optmdfpathway_dialog.py
+++ b/cnapy/gui_elements/optmdfpathway_dialog.py
@@ -1,0 +1,233 @@
+"""The CNApy OptMDFpathway dialog"""
+import cobra
+import copy
+from numpy import exp
+from qtpy.QtCore import Qt, Signal, Slot
+from qtpy.QtWidgets import (QDialog, QHBoxLayout, QLabel, QComboBox,
+                            QMessageBox, QPushButton, QVBoxLayout)
+
+from cnapy.appdata import AppData
+from cnapy.gui_elements.central_widget import CentralWidget
+from cnapy.utils import QComplReceivLineEdit
+from straindesign import fba, linexpr2dict, linexprdict2str, avail_solvers
+from straindesign.names import *
+from cnapy.sd_class_interface import LinearProgram, Solver, Status
+from cnapy.sd_ci_optmdfpathway import create_optmdfpathway_milp, STANDARD_R, STANDARD_T
+from typing import Dict
+from cobra.util.solver import interface_to_str
+import re
+
+
+def make_model_irreversible(cobra_model: cobra.Model,
+                            forward_id:str = "_FWD", reverse_id: str="_REV") -> cobra.Model:
+    # Create
+    cobra_reaction_ids = [x.id for x in cobra_model.reactions]
+    for cobra_reaction_id in cobra_reaction_ids:
+        cobra_reaction: cobra.Reaction = cobra_model.reactions.get_by_id(cobra_reaction_id)
+
+        create_forward = False
+        create_reverse = False
+        if cobra_reaction.lower_bound < 0:
+            create_reverse = True
+        elif (cobra_reaction.lower_bound == 0) and (cobra_reaction.upper_bound == 0):
+            create_reverse = True
+            create_forward = True
+        elif (cobra_reaction.id.startswith("EX_")):
+            create_reverse = True
+            create_forward = True
+        else:
+            continue
+
+        if cobra_reaction.upper_bound > 0:
+            create_forward = True
+
+        if create_forward:
+            forward_reaction_id = cobra_reaction.id + forward_id
+            forward_reaction = copy.deepcopy(cobra_reaction)
+            forward_reaction.id = forward_reaction_id
+            if cobra_reaction.lower_bound >= 0:
+                forward_reaction.lower_bound = cobra_reaction.lower_bound
+            else:
+                forward_reaction.lower_bound = 0
+            cobra_model.add_reactions([forward_reaction])
+
+        if create_reverse:
+            reverse_reaction_id = cobra_reaction.id + reverse_id
+            reverse_reaction = copy.deepcopy(cobra_reaction)
+            reverse_reaction.id = reverse_reaction_id
+
+            metabolites_to_add = {}
+            for metabolite in reverse_reaction.metabolites:
+                metabolites_to_add[metabolite] = reverse_reaction.metabolites[metabolite] * -2
+            reverse_reaction.add_metabolites(metabolites_to_add)
+
+            if cobra_reaction.upper_bound < 0:
+                reverse_reaction.lower_bound = -cobra_reaction.upper_bound
+            else:
+                reverse_reaction.lower_bound = 0
+            reverse_reaction.upper_bound = -cobra_reaction.lower_bound
+
+            cobra_model.add_reactions([reverse_reaction])
+
+        if create_forward or create_reverse:
+            cobra_model.remove_reactions([cobra_reaction])
+
+    return cobra_model
+
+
+class OptmdfpathwayDialog(QDialog):
+    """A dialog to perform OptMDFpathway"""
+
+    def __init__(self, appdata: AppData, central_widget: CentralWidget) -> None:
+        self.FWDID = "_FWDCNAPY"
+        self.REVID = "_REVCNAPY"
+
+        QDialog.__init__(self)
+        self.setWindowTitle("Perform OptMDFpathway")
+
+        self.appdata = appdata
+        self.central_widget = central_widget
+
+        self.reac_ids = self.appdata.project.cobra_py_model.reactions.list_attr("id")
+        self.metabolite_ids = self.appdata.project.cobra_py_model.metabolites.list_attr("id")
+
+        self.layout = QVBoxLayout()
+        l = QLabel(
+            "Perform OptMDFpathway. dG'° values and metabolite concentration "
+            "ranges have to be given in relevant annotations.\nWhat shall be shown afterwards?"
+        )
+        self.layout.addWidget(l)
+        editor_layout = QHBoxLayout()
+        self.show_combo = QComboBox()
+        self.show_combo.insertItems(0, ['fluxes', 'driving forces'])
+        self.show_combo.setMinimumWidth(120)
+        editor_layout.addWidget(self.show_combo)
+        self.layout.addItem(editor_layout)
+
+        l3 = QHBoxLayout()
+        self.button = QPushButton("Compute")
+        self.cancel = QPushButton("Close")
+        l3.addWidget(self.button)
+        l3.addWidget(self.cancel)
+        self.layout.addItem(l3)
+        self.setLayout(self.layout)
+
+        # Connecting the signal
+        self.cancel.clicked.connect(self.reject)
+        self.button.clicked.connect(self.compute)
+
+    def compute(self) -> None:
+        self.setCursor(Qt.BusyCursor)
+
+        dG0_values: Dict[str, Dict[str, float]] = {}
+        for reaction in self.appdata.project.cobra_py_model.reactions:
+            reaction: cobra.Reaction = reaction
+            if "dG0" in reaction.annotation.keys():
+                dG0_values[reaction.id] = {}
+                dG0_values[reaction.id+self.FWDID] = {}
+                dG0_values[reaction.id+self.REVID] = {}
+                dG0_values[reaction.id]["dG0"] = float(reaction.annotation["dG0"])
+                dG0_values[reaction.id+self.FWDID]["dG0"] = float(reaction.annotation["dG0"])
+                dG0_values[reaction.id+self.REVID]["dG0"] = -float(reaction.annotation["dG0"])
+                if "dG0_uncertainty" in reaction.annotation.keys():
+                    dG0_values[reaction.id]["uncertainty"] = float(reaction.annotation["dG0_uncertainty"])
+                    dG0_values[reaction.id+self.FWDID]["uncertainty"] = float(reaction.annotation["dG0_uncertainty"])
+                    dG0_values[reaction.id+self.REVID]["uncertainty"] = float(reaction.annotation["dG0_uncertainty"])
+                else:
+                    dG0_values[reaction.id]["uncertainty"] = 0.0
+
+        concentration_values: Dict[str, Dict[str, float]] = {}
+        for metabolite in self.appdata.project.cobra_py_model.metabolites:
+            metabolite: cobra.Metabolite = metabolite
+            if ("Cmin" in metabolite.annotation.keys()) and ("Cmax" in metabolite.annotation.keys()):
+                concentration_values[metabolite.id] = {}
+                concentration_values[metabolite.id]["min"] = float(metabolite.annotation["Cmin"])
+                concentration_values[metabolite.id]["max"] = float(metabolite.annotation["Cmax"])
+
+        # optlang_solver_name = interface_to_str(self.appdata.project.cobra_py_model.problem)
+
+        with self.appdata.project.cobra_py_model as model:
+            self.appdata.project.load_scenario_into_model(model)
+            solvers = re.search('('+'|'.join(avail_solvers)+')',model.solver.interface.__name__)
+            if solvers is not None:
+                solver_str = solvers[0]
+            if solver_str == "cplex":
+                solver = Solver.CPLEX
+            elif solver_str == "gurobi":
+                solver = Solver.GUROBI
+            else:
+                solver = Solver.GLPK
+
+            R = STANDARD_R
+            T = STANDARD_T
+            optmdfpathway_lp = create_optmdfpathway_milp(
+                cobra_model=make_model_irreversible(cobra_model=model, forward_id=self.FWDID, reverse_id=self.REVID),
+                dG0_values=dG0_values,
+                concentration_values=concentration_values,
+                extra_constraints=[],
+                ratio_constraints=[],
+                R=R,
+                T=T,
+            )
+            optmdfpathway_lp.construct_solver_object(
+                solver=solver,
+            )
+            solution = optmdfpathway_lp.run_solve()
+
+            if solution.status == Status.INFEASIBLE:
+                QMessageBox.warning(self, "Infeasible",
+                                    "No solution exists, the problem is infeasible")
+            elif solution.status == Status.TIME_LIMIT:
+                QMessageBox.warning(self, "Time limit hit",
+                                    "No solution could be calculated as the time limit was hit.")
+            elif solution.status == Status.UNBOUNDED:
+                QMessageBox.warning(self, "Unbounded",
+                                    "The OptMDF is unbounded (inf) so that no optimization solution can be shown.")
+            elif solution.status == Status.OPTIMAL:
+                self.set_boxes(solution=solution.values)
+
+            self.setCursor(Qt.ArrowCursor)
+            self.accept()
+
+    def set_boxes(self, solution: Dict[str, float]):
+        # Combine FWD and REV flux solutions
+        combined_solution = {}
+        for var_id in solution.keys():
+            if var_id.endswith(self.FWDID):
+                key = var_id.replace(self.FWDID, "")
+                multiplier = 1.0
+            elif var_id.endswith(self.REVID):
+                key = var_id.replace(self.REVID, "")
+                multiplier = -1.0
+            else:
+                key = var_id
+                multiplier = 1.0
+            if key not in combined_solution.keys():
+                combined_solution[key] = 0.0
+            combined_solution[key] += multiplier * solution[var_id]
+
+        # write results into comp_values
+        for r in self.reac_ids:
+            if self.show_combo.currentText() == "fluxes":
+                search_key = r
+            elif self.show_combo.currentText() == "driving forces":
+                search_key = "f_var_"+r
+            if r in combined_solution.keys():
+                self.appdata.project.comp_values[r] = (
+                    float(combined_solution[r]), float(combined_solution[r]))
+
+        # Write metabolite concentrations
+        for metabolite_id in self.metabolite_ids:
+            var_id = f"x_{metabolite_id}"
+            if var_id in solution.keys():
+                print(var_id, solution[var_id])
+                self.appdata.project.conc_values[var_id[2:]] = exp(solution[var_id])
+
+        # Show selected reaction-dependent values
+        self.appdata.project.comp_values_type = 0
+        self.central_widget.update()
+
+        # Show OptMDF
+        optmdf = combined_solution["var_B"]
+        self.central_widget.kernel_client.execute(f"print('\\nOptMDF: {optmdf} kJ/mol')")
+        self.central_widget.show_bottom_of_console()

--- a/cnapy/gui_elements/optmdfpathway_dialog.py
+++ b/cnapy/gui_elements/optmdfpathway_dialog.py
@@ -366,7 +366,7 @@ class OptmdfpathwayDialog(QDialog):
         for metabolite_id in self.metabolite_ids:
             var_id = f"x_{metabolite_id}"
             if var_id in solution.keys():
-                self.appdata.project.conc_values[var_id[2:]] = exp(solution[var_id])
+                self.appdata.project.conc_values[var_id[2:]] = round(exp(solution[var_id]), 6)
 
         # Show selected reaction-dependent values
         self.appdata.project.comp_values_type = 0

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -27,6 +27,7 @@ class ReactionListColumn(IntEnum):
     Flux = 3
     LB = 4
     UB = 5
+    DF = 6
 
 class DragableTreeWidget(QTreeWidget):
     '''A list of dragable reaction items'''
@@ -154,6 +155,8 @@ class ReactionList(QWidget):
             self.emit_jump_to_metabolite)
 
         self.add_button.clicked.connect(self.add_new_reaction)
+        self.reaction_list.setColumnHidden(ReactionListColumn.DF, True)
+        self.visible_column[ReactionListColumn.DF] = False
 
     def clear(self):
         self.reaction_list.clear()
@@ -192,6 +195,8 @@ class ReactionList(QWidget):
             scen_text = ""
         item.setBackground(ReactionListColumn.Scenario, scen_background_color)
         item.setText(ReactionListColumn.Scenario, scen_text)
+        if item.reaction.id in self.appdata.project.df_values.keys():
+            item.setText(ReactionListColumn.DF, str(self.appdata.project.df_values[item.reaction.id]))
 
     def set_flux_value(self, item: ReactionListItem):
         key = item.reaction.id
@@ -378,6 +383,10 @@ class ReactionList(QWidget):
         )
 
     def update(self, rebuild=False):
+        if len(self.appdata.project.df_values.keys()) > 0:
+            self.reaction_list.setColumnHidden(ReactionListColumn.DF, False)
+            self.visible_column[ReactionListColumn.DF] = True
+
         # should only need to rebuild the whole list if the model changes
         self.reaction_list.itemChanged.disconnect(self.handle_item_changed)
         self.reaction_list.setSortingEnabled(False) # keep row order stable so that each item is updated

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -83,6 +83,8 @@ class ReactionListItem(QTreeWidgetItem):
             return self.lb_val < other.lb_val
         elif column == ReactionListColumn.UB:
             return self.ub_val < other.ub_val
+        elif column == ReactionListColumn.DF:
+            return self.df_val < other.df_val
         else:  # use Qt default comparison for the other columns
 #            return super().__lt__(other) # infinite recursion with PySide2, __lt__ is a virtual function of QTreeWidgetItem
             return self.text(column) < other.text(column)
@@ -198,6 +200,7 @@ class ReactionList(QWidget):
         item.setText(ReactionListColumn.Scenario, scen_text)
         if item.reaction.id in self.appdata.project.df_values.keys():
             item.setText(ReactionListColumn.DF, str(self.appdata.project.df_values[item.reaction.id]))
+            item.df_val = self.appdata.project.df_values[item.reaction.id]
 
     def set_flux_value(self, item: ReactionListItem):
         key = item.reaction.id

--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -53,6 +53,7 @@ class ReactionListItem(QTreeWidgetItem):
         self.flux_sort_val = -float('inf')
         self.lb_val = -float('inf')
         self.ub_val = float('inf')
+        self.df_val = -float("inf")
         self.pin_at_top = False
 
     def set_flux_data(self, text, value):
@@ -413,6 +414,7 @@ class ReactionList(QWidget):
         self.reaction_list.resizeColumnToContents(ReactionListColumn.Flux)
         self.reaction_list.resizeColumnToContents(ReactionListColumn.LB)
         self.reaction_list.resizeColumnToContents(ReactionListColumn.UB)
+        self.reaction_list.resizeColumnToContents(ReactionListColumn.DF)
 
     def set_current_item(self, key: str):
         self.last_selected = key

--- a/cnapy/gui_elements/solver_buttons.py
+++ b/cnapy/gui_elements/solver_buttons.py
@@ -1,0 +1,69 @@
+from qtpy.QtWidgets import (QButtonGroup, QRadioButton, QVBoxLayout)
+from straindesign.names import CPLEX, GUROBI, GLPK, SCIP
+from importlib import find_loader as module_exists
+from typing import Tuple
+from straindesign import select_solver
+
+
+def get_solver_buttons(appdata) -> Tuple[QVBoxLayout, QButtonGroup]:
+    # find available solvers
+    avail_solvers = []
+    if module_exists('cplex'):
+        avail_solvers += [CPLEX]
+    if module_exists('gurobipy'):
+        avail_solvers += [GUROBI]
+    if module_exists('swiglpk'):
+        avail_solvers += [GLPK]
+    if module_exists('pyscipopt'):
+        avail_solvers += [SCIP]
+
+    # Get solver button group
+    solver_buttons_layout = QVBoxLayout()
+    solver_buttons = {}
+    solver_buttons["group"] = QButtonGroup()
+    # CPLEX
+    solver_buttons[CPLEX] = QRadioButton("IBM CPLEX")
+    solver_buttons[CPLEX].setProperty('name', CPLEX)
+    if CPLEX not in avail_solvers:
+        solver_buttons[CPLEX].setEnabled(False)
+        solver_buttons[CPLEX].setToolTip('CPLEX is not set up with your python environment. '+\
+            'Install CPLEX and follow the steps of the python setup \n'+\
+            r'(https://www.ibm.com/docs/en/icos/22.1.0?topic=cplex-setting-up-python-api)')
+    solver_buttons_layout.addWidget(solver_buttons[CPLEX])
+    solver_buttons["group"].addButton(solver_buttons[CPLEX])
+    # Gurobi
+    solver_buttons[GUROBI] = QRadioButton("Gurobi")
+    solver_buttons[GUROBI].setProperty('name',GUROBI)
+    if GUROBI not in avail_solvers:
+        solver_buttons[GUROBI].setEnabled(False)
+        solver_buttons[GUROBI].setToolTip('Gurobi is not set up with your python environment. '+\
+        'Install Gurobi and follow the steps of the python setup (preferably option 3) \n'+\
+        r'(https://support.gurobi.com/hc/en-us/articles/360044290292-How-do-I-install-Gurobi-for-Python-)')
+    solver_buttons_layout.addWidget(solver_buttons[GUROBI])
+    solver_buttons["group"].addButton(solver_buttons[GUROBI])
+    # GLPK
+    solver_buttons[GLPK] = QRadioButton("GLPK")
+    solver_buttons[GLPK].setProperty('name',GLPK)
+    if GLPK not in avail_solvers:
+        solver_buttons[GLPK].setEnabled(False)
+        solver_buttons[GLPK].setToolTip('GLPK is not set up with your python environment. '+\
+        'GLPK should have been installed together with the COBRA toolbox. \n'\
+        'Reinstall the COBRA toolbox for your Python environment.')
+    solver_buttons_layout.addWidget(solver_buttons[GLPK])
+    solver_buttons["group"].addButton(solver_buttons[GLPK])
+    # SCIP
+    solver_buttons[SCIP] = QRadioButton("SCIP")
+    solver_buttons[SCIP].setProperty('name',SCIP)
+    if SCIP not in avail_solvers:
+        solver_buttons[SCIP].setEnabled(False)
+        solver_buttons[SCIP].setToolTip('SCIP is not set up with your python environment. '+\
+        'Install SCIP following the steps of the PySCIPOpt manual \n'+\
+        r'(https://github.com/scipopt/PySCIPOpt')
+    solver_buttons_layout.addWidget(solver_buttons[SCIP])
+    solver_buttons["group"].addButton(solver_buttons[SCIP])
+    # check best available solver
+    if avail_solvers:
+        solver = select_solver(GLPK, appdata.project.cobra_py_model)
+        solver_buttons[solver].setChecked(True)
+
+    return solver_buttons_layout, solver_buttons

--- a/cnapy/gui_elements/strain_design_dialog.py
+++ b/cnapy/gui_elements/strain_design_dialog.py
@@ -20,6 +20,7 @@ from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QCompleter,
                             QRadioButton, QTableWidget, QVBoxLayout, QSplitter,
                             QWidget, QFileDialog, QTextEdit, QLayout, QScrollArea)
 from cnapy.appdata import AppData
+from cnapy.gui_elements.solver_buttons import get_solver_buttons
 from cnapy.utils import QTableCopyable, QComplReceivLineEdit, QTableItem
 import logging
 
@@ -316,70 +317,12 @@ class SDDialog(QDialog):
         params_layout.addWidget(checkboxes)
 
         ## Solver and solving options
-        # find available solvers
-        avail_solvers = []
-        if module_exists('cplex'):
-            avail_solvers += [CPLEX]
-        if module_exists('gurobipy'):
-            avail_solvers += [GUROBI]
-        if module_exists('swiglpk'):
-            avail_solvers += [GLPK]
-        if module_exists('pyscipopt'):
-            avail_solvers += [SCIP]
-
         solver_and_solution_group = QGroupBox("Solver and solution approach")
         solver_and_solution_group.setObjectName("Solver_and_solution")
         solver_and_solution_layout = QHBoxLayout()
 
-        solver_buttons_layout = QVBoxLayout()
-        self.solver_buttons = {}
-        self.solver_buttons["group"] = QButtonGroup()
-        # CPLEX
-        self.solver_buttons[CPLEX] = QRadioButton("IBM CPLEX")
-        self.solver_buttons[CPLEX].setProperty('name',CPLEX)
-        if CPLEX not in avail_solvers:
-            self.solver_buttons[CPLEX].setEnabled(False)
-            self.solver_buttons[CPLEX].setToolTip('CPLEX is not set up with your python environment. '+\
-                'Install CPLEX and follow the steps of the python setup \n'+\
-                r'(https://www.ibm.com/docs/en/icos/22.1.0?topic=cplex-setting-up-python-api)')
-        solver_buttons_layout.addWidget(self.solver_buttons[CPLEX])
-        self.solver_buttons["group"].addButton(self.solver_buttons[CPLEX])
-        # Gurobi
-        self.solver_buttons[GUROBI] = QRadioButton("Gurobi")
-        self.solver_buttons[GUROBI].setProperty('name',GUROBI)
-        if GUROBI not in avail_solvers:
-            self.solver_buttons[GUROBI].setEnabled(False)
-            self.solver_buttons[GUROBI].setToolTip('Gurobi is not set up with your python environment. '+\
-            'Install Gurobi and follow the steps of the python setup (preferably option 3) \n'+\
-            r'(https://support.gurobi.com/hc/en-us/articles/360044290292-How-do-I-install-Gurobi-for-Python-)')
-        solver_buttons_layout.addWidget(self.solver_buttons[GUROBI])
-        self.solver_buttons["group"].addButton(self.solver_buttons[GUROBI])
-        # GLPK
-        self.solver_buttons[GLPK] = QRadioButton("GLPK")
-        self.solver_buttons[GLPK].setProperty('name',GLPK)
-        if GLPK not in avail_solvers:
-            self.solver_buttons[GLPK].setEnabled(False)
-            self.solver_buttons[GLPK].setToolTip('GLPK is not set up with your python environment. '+\
-            'GLPK should have been installed together with the COBRA toolbox. \n'\
-            'Reinstall the COBRA toolbox for your Python environment.')
-        solver_buttons_layout.addWidget(self.solver_buttons[GLPK])
-        self.solver_buttons["group"].addButton(self.solver_buttons[GLPK])
-        # SCIP
-        self.solver_buttons[SCIP] = QRadioButton("SCIP")
-        self.solver_buttons[SCIP].setProperty('name',SCIP)
-        if SCIP not in avail_solvers:
-            self.solver_buttons[SCIP].setEnabled(False)
-            self.solver_buttons[SCIP].setToolTip('SCIP is not set up with your python environment. '+\
-            'Install SCIP following the steps of the PySCIPOpt manual \n'+\
-            r'(https://github.com/scipopt/PySCIPOpt')
-        solver_buttons_layout.addWidget(self.solver_buttons[SCIP])
-        self.solver_buttons["group"].addButton(self.solver_buttons[SCIP])
-        self.solver_buttons["group"].buttonClicked.connect(self.configure_solver_options)
+        solver_buttons_layout, self.solver_buttons = get_solver_buttons(appdata)
         solver_and_solution_layout.addItem(solver_buttons_layout)
-        # check best available solver
-        if avail_solvers:
-            solver = select_solver(GLPK,self.appdata.project.cobra_py_model)
-            self.solver_buttons[solver].setChecked(True)
 
         solution_buttons_layout = QVBoxLayout()
         self.solution_buttons = {}

--- a/cnapy/sd_ci_optmdfpathway.py
+++ b/cnapy/sd_ci_optmdfpathway.py
@@ -47,6 +47,8 @@ def get_steady_state_lp_from_cobra_model(
     extra_constraint_counter = 0
     for extra_constraint in extra_constraints:
         extra_constraint_lhs: Dict[str, float] = {}
+        has_lb = False
+        has_ub = False
         for key in extra_constraint.keys():
             if key == "lb":
                 has_lb = True

--- a/cnapy/sd_ci_optmdfpathway.py
+++ b/cnapy/sd_ci_optmdfpathway.py
@@ -210,6 +210,38 @@ def create_optmdfpathway_milp(
         z_varname = f"z_var_{reaction.id}"
         lp.add_binary_variable(name=z_varname)
 
+        """
+        ALTERNATIVE BIG M FORMULATION:
+        z_zero_constraint_lhs = {
+            reaction.id: 1.0,
+            z_varname: -M,
+        }
+        z_zero_constraint_rhs = 0.0
+        lp.add_constraint(
+            name=f"z_zero_{reaction.id}",
+            lhs=z_zero_constraint_lhs,
+            sense=ConstraintSense.LEQ,
+            rhs=z_zero_constraint_rhs,
+        )
+
+        # z_r = 1 -> f_r >= B == f_r - B >= 0
+        # In Big M form: f_r + (1-z_i)*M >= B
+        # z_one_constraint: pulp.LpConstraint = 0.0
+        # z_one_constraint = var_B <= current_f_variable + (1-current_z_variable)*M
+        z_one_constraint_lhs = {
+            f_varname: 1.0,
+            z_varname: -M,
+            var_B.name: -1.0,
+        }
+        z_one_constraint_rhs = -M
+        lp.add_constraint(
+            name=f"z_one_{reaction.id}",
+            lhs=z_one_constraint_lhs,
+            sense=ConstraintSense.GEQ,
+            rhs=z_one_constraint_rhs,
+        )
+        """
+
         indicator_0_lhs = {
             reaction.id: 1,
         }

--- a/cnapy/sd_ci_optmdfpathway.py
+++ b/cnapy/sd_ci_optmdfpathway.py
@@ -3,7 +3,13 @@
 import cobra
 
 # Internal packages
-from cnapy.sd_class_interface import BinaryValue, ConstraintSense, IndicatorConstraint, FloatVariable, LinearProgram
+from cnapy.sd_class_interface import (
+    BinaryValue,
+    ConstraintSense,
+    IndicatorConstraint,
+    FloatVariable,
+    LinearProgram,
+)
 from numpy import log
 from typing import Any, List, Dict
 
@@ -185,8 +191,8 @@ def create_optmdfpathway_milp(
         dG0_uncertainty = abs(dG0_values[reaction.id]["uncertainty"])
         dG0_var = FloatVariable(
             name=f"dG0_{reaction.id}",
-            lb=dG0_value-dG0_uncertainty,
-            ub=dG0_value+dG0_uncertainty,
+            lb=dG0_value - dG0_uncertainty,
+            ub=dG0_value + dG0_uncertainty,
         )
         lp.add_existing_float_variable(dG0_var)
 

--- a/cnapy/sd_ci_optmdfpathway.py
+++ b/cnapy/sd_ci_optmdfpathway.py
@@ -1,0 +1,238 @@
+# IMPORTS SECTION #
+# External packages
+import cobra
+
+# Internal packages
+from cnapy.sd_class_interface import BinaryValue, ConstraintSense, IndicatorConstraint, FloatVariable, LinearProgram
+from numpy import log
+from typing import Any, List, Dict
+
+
+# CONSTANTS #
+STANDARD_R = 8.314e-3  # kJ⋅K⁻1⋅mol⁻1 (standard value is in J⋅K⁻1⋅mol⁻1)
+"""Standard gas constant in kJ⋅K⁻1⋅mol⁻1."""
+STANDARD_T = 298.15  # K
+"""Standard temperature in Kelvin."""
+
+
+# PUBLIC FUNCTIONS #
+def get_steady_state_lp_from_cobra_model(
+    cobra_model: cobra.Model, extra_constraints: List[Dict[str, float]] = []
+) -> LinearProgram:
+    lp = LinearProgram()
+
+    for reaction in cobra_model.reactions:
+        reaction: cobra.Reaction = reaction
+        reaction_var = FloatVariable(
+            name=reaction.id,
+            lb=reaction.lower_bound,
+            ub=reaction.upper_bound,
+        )
+        lp.add_existing_float_variable(reaction_var)
+
+    for metabolite in cobra_model.metabolites:
+        metabolite: cobra.Metabolite = metabolite
+        constraint_name = f"Steady-state of {metabolite.id}"
+        constraint_lhs = {
+            reaction.id: reaction.metabolites[metabolite]
+            for reaction in metabolite.reactions
+        }
+        lp.add_constraint(
+            name=constraint_name,
+            lhs=constraint_lhs,
+            rhs=0,
+            sense=ConstraintSense.EQ,
+        )
+
+    extra_constraint_counter = 0
+    for extra_constraint in extra_constraints:
+        extra_constraint_lhs: Dict[str, float] = {}
+        for key in extra_constraint.keys():
+            if key == "lb":
+                has_lb = True
+                lb = extra_constraint["lb"]
+            elif key == "ub":
+                has_ub = True
+                ub = extra_constraint["ub"]
+            else:
+                extra_constraint_lhs[key] = extra_constraint[key]
+
+        base_extra_constraint_name = f"Extra_constraint_{extra_constraint_counter}_"
+
+        if has_lb:
+            lp.add_constraint(
+                name=f"{base_extra_constraint_name}LB",
+                lhs=extra_constraint_lhs,
+                rhs=lb,
+                sense=ConstraintSense.GEQ,
+            )
+
+        if has_ub:
+            lp.add_constraint(
+                name=f"{base_extra_constraint_name}UB",
+                lhs=extra_constraint_lhs,
+                rhs=ub,
+                sense=ConstraintSense.LEQ,
+            )
+        extra_constraint_counter += 1
+
+    return lp
+
+
+def create_optmdfpathway_milp(
+    cobra_model: cobra.Model,
+    dG0_values: Dict[str, Dict[str, float]],
+    concentration_values: Dict[str, Dict[str, float]],
+    extra_constraints: List[Dict[str, float]] = [],
+    ratio_constraints: List[Dict[str, Any]] = [],
+    R: float = STANDARD_R,
+    T: float = STANDARD_T,
+) -> LinearProgram:
+    lp = get_steady_state_lp_from_cobra_model(
+        cobra_model=cobra_model,
+        extra_constraints=extra_constraints,
+    )
+
+    # Set metabolite variables
+    for metabolite in cobra_model.metabolites:
+        metabolite: cobra.Metabolite = metabolite
+
+        if metabolite.id in concentration_values.keys():
+            concentration_key = metabolite.id
+        else:
+            concentration_key = "DEFAULT"
+
+        lower_concentration = log(concentration_values[concentration_key]["min"])
+        upper_concentration = log(concentration_values[concentration_key]["max"])
+
+        lp.add_float_variable(
+            name=f"x_{metabolite.id}",
+            lb=lower_concentration,
+            ub=upper_concentration,
+        )
+
+    # Set concentration ratio ranges
+    ratio_counter = 0
+    for ratio_constraint in ratio_constraints:
+        # c_i / c_j <= h_max AND c_i / c_j >= h_min
+        # <=> x_i - x_j <= ln(h_max) AND x_i - x_j >= ln(h_min)
+        # <=> (A) x_i - x_j - ln(h_max) <= 0 AND (B) -x_i + x_j - ln(h_min) <= 0
+        c_i_id = ratio_constraint["c_i"]
+        c_j_id = ratio_constraint["c_j"]
+
+        ln_h_max = log(ratio_constraint["h_max"])
+        ln_h_max_var = FloatVariable(
+            name=f"ln_h_max_{ratio_counter}",
+            lb=ln_h_max,
+            ub=ln_h_max,
+        )
+        ln_h_min = log(ratio_constraint["h_min"])
+        ln_h_min_var = FloatVariable(
+            name=f"ln_h_min_{ratio_counter}",
+            lb=ln_h_min,
+            ub=ln_h_min,
+        )
+
+        # (A) x_i - x_j - ln(h_max) <= 0
+        lp.add_constraint(
+            name=f"max_ratio_constraint_{ratio_counter}",
+            lhs={
+                c_i_id: 1.0,
+                c_j_id: -1.0,
+                ln_h_max_var: -1.0,
+            },
+            sense=ConstraintSense.LEQ,
+            rhs=0,
+        )
+        # (B) -x_i + x_j - ln(h_min) <= 0
+        lp.add_constraint(
+            name=f"min_ratio_constraint_{ratio_counter}",
+            lhs={
+                c_i_id: -1.0,
+                c_j_id: +1.0,
+                ln_h_min_var: -1.0,
+            },
+            sense=ConstraintSense.LEQ,
+            rhs=0,
+        )
+
+        ratio_counter += 1
+
+    # Set reaction driving force constraints
+    var_B = FloatVariable(
+        name=f"var_B",
+        lb=-float("inf"),
+        ub=float("inf"),
+    )
+    lp.add_existing_float_variable(var_B)
+    for reaction in cobra_model.reactions:
+        reaction: cobra.Reaction = reaction
+
+        if reaction.id not in dG0_values.keys():
+            continue
+
+        f_varname = f"f_var_{reaction.id}"
+        f_var = FloatVariable(
+            name=f_varname,
+            lb=-float("inf"),
+            ub=float("inf"),
+        )
+        lp.add_existing_float_variable(f_var)
+
+        dG0_value = dG0_values[reaction.id]["dG0"]
+        dG0_uncertainty = abs(dG0_values[reaction.id]["uncertainty"])
+        dG0_var = FloatVariable(
+            name=f"dG0_{reaction.id}",
+            lb=dG0_value-dG0_uncertainty,
+            ub=dG0_value+dG0_uncertainty,
+        )
+        lp.add_existing_float_variable(dG0_var)
+
+        # e.g.,
+        #     RT * ln(([S]*[T])/([A]²*[B]))
+        # <=> RT*ln([S]) + RT*ln([T]) - 2*RT*ln([A]) - RT*ln([B])
+        f_expression_lhs: Dict[str, float] = {
+            f_varname: -1,
+            dG0_var.name: -1,
+        }
+        for metabolite in reaction.metabolites:
+            stoichiometry = reaction.metabolites[metabolite]
+            f_expression_lhs[f"x_{metabolite.id}"] = (-1) * stoichiometry * R * T
+        lp.add_constraint(
+            name=f"f_var_constraint_{reaction.id}",
+            lhs=f_expression_lhs,
+            sense=ConstraintSense.EQ,
+            rhs=0,
+        )
+
+        z_varname = f"z_var_{reaction.id}"
+        lp.add_binary_variable(name=z_varname)
+
+        indicator_0_lhs = {
+            reaction.id: 1,
+        }
+        indicator_0 = IndicatorConstraint(
+            name=f"indicator_0_{reaction.id}",
+            lhs=indicator_0_lhs,
+            rhs=0,
+            sense=ConstraintSense.EQ,
+            binary_name=z_varname,
+            binary_value=BinaryValue.ZERO,
+        )
+        lp.add_existing_indicator_constraint(indicator_constraint=indicator_0)
+
+        indicator_1_lhs = {
+            "var_B": 1,
+            f_varname: -1,
+        }
+        indicator_1 = IndicatorConstraint(
+            name=f"indicator_1_{reaction.id}",
+            lhs=indicator_1_lhs,
+            rhs=0,
+            sense=ConstraintSense.LEQ,
+            binary_name=z_varname,
+            binary_value=BinaryValue.ONE,
+        )
+        lp.add_existing_indicator_constraint(indicator_constraint=indicator_1)
+
+    return lp

--- a/cnapy/sd_class_interface.py
+++ b/cnapy/sd_class_interface.py
@@ -69,7 +69,7 @@ class Solver(Enum):
 
     CPLEX = "cplex"
     """The IBM CPLEX (c) solver."""
-    GLPK = "GLPK"
+    GLPK = "glpk"
     """The open-source GNU Linear Programming kit."""
     GUROBI = "gurobi"
     """The Gurobi (c) solver."""

--- a/cnapy/sd_class_interface.py
+++ b/cnapy/sd_class_interface.py
@@ -1,0 +1,825 @@
+"""
+"""
+
+# IMPORTS SECTION #
+# External packages
+from dataclasses import dataclass
+from enum import Enum
+from os import cpu_count
+from numpy import array_split, linspace
+# import ray
+from scipy import sparse
+from typing import Any, Callable, Dict, List, Tuple, Union
+# from helper import json_write, json_load
+
+# Internal packages
+from straindesign.indicatorConstraints import IndicatorConstraints
+from straindesign.solver_interface import MILP_LP
+
+
+# ENUMS SECTION #
+class ConstraintSense(Enum):
+    """
+    Shows the directional sense of a constraint, e.g., the constraint...
+
+    A + 2 B <= 2
+
+    ...has the sense "lower equal" (<=). With (MI)LPs, possible senses are:
+
+    1. Lower equal (<=; LEQ)
+    2. Equal (==; EQ)
+    3. Greater equal (>=; GEQ)
+    """
+
+    LEQ = 1
+    """<=; Lower equal"""
+    EQ = 2
+    """==; Equal"""
+    GEQ = 3
+    """>=; Greater equal"""
+
+
+class BinaryValue(Enum):
+    """
+    Shows the value of a binary variable, i.e. either 1 or 0.
+    This is used in defining indicator constraints. It is *not*
+    intended to be used within constraints.
+    """
+
+    ZERO = 0
+    """The integer 0"""
+    ONE = 1
+    """The integer 1"""
+
+
+class ObjectiveDirection(Enum):
+    """
+    Indicates the direction of the LinearProgram's objective, i.e.
+    either a minimization (MIN) or maximization (MAX).
+    """
+
+    MIN = 0
+    """Minimize objective function"""
+    MAX = 1
+    """Maximize objective function"""
+
+
+class Solver(Enum):
+    """Shows for which solver a LinearProgram shall be constructed."""
+
+    CPLEX = "cplex"
+    """The IBM CPLEX (c) solver."""
+    GLPK = "GLPK"
+    """The open-source GNU Linear Programming kit."""
+    GUROBI = "gurobi"
+    """The Gurobi (c) solver."""
+    SCIP = "scip"
+    """The open-source Solving Constraint Integer Programs suite."""
+
+
+class Status(Enum):
+    """
+    The status of a LinearProgram solution after a solver run.
+    It can be either 'OPTIMAL', 'INFEASIBLE', 'UNBOUNDED' or 'TIME_LIMIT'.
+    See the member variable's associated description for more about these statuses.
+    """
+
+    OPTIMAL = "optimal"
+    """Optimal status, i.e. a feasible and optimal solution was found."""
+    INFEASIBLE = "infeasible"
+    """Infeasible status, i.e. no feasible solution could be found."""
+    UNBOUNDED = "unbounded"
+    """Unbounded status, i.e. a feasible solution can be found but it is either infinite or -infinite."""
+    TIME_LIMIT = "time_limit"
+    """Time limit status, i.e., so feasible solution could be found before the user-defined timelimit was hit."""
+    UNKNOWN = "unknown"
+    """A status from StrainDesign which could not be identified. If this happens, a severe error must have occured."""
+
+
+# DATACLASS SECTION #
+@dataclass
+class FloatVariable:
+    """A continuous (MI)LP variable which can hold values between -float('inf') and +float('inf')."""
+
+    name: str
+    """Identifying name of float variable"""
+    lb: float
+    """Lower bound of float variable"""
+    ub: float
+    """"Upper bound of float variable"""
+
+
+@dataclass
+class BinaryVariable:
+    """An integer (MI)LP variable which can be either 0 or 1."""
+
+    name: str
+    """Identifying name of binary variable"""
+
+
+@dataclass
+class Constraint:
+    """A (MI)LP constraint. See the description of the member variables to find out more."""
+
+    name: str
+    """Identifying name of constraint"""
+    lhs: Dict[str, float]
+    """
+    Definition
+    ===
+    Left hand side of constraint in the form of a dictionary where
+    the variable names are the keys, and the coefficcients are
+
+    Example
+    ===
+    E.g., in the constraint '2A+B-C-2D<=0', the left hand side is '2A+B-C-2D'.
+    There, the coefficient of variable 'A' is 2, the one of 'B' is 1, the one of
+    C is  -1 and the one of D is -2. Hence, the resulting lhs dict is as follows:
+
+    {
+        'A': 2,
+        'B': 1,
+        'C': -1,
+        'D': -2,
+    }
+
+    The order of variables in this lhs dict has no matter, e.g., 'B' may also appear
+    before 'A' in the dict as long as their respective coefficients are also switched.
+    """
+    rhs: float
+    """
+    The right hand side of the constraint. E.g., in the constraint '2A+B-C-2D<=2.32',
+    the right hand side is 2.32.
+    """
+    sense: ConstraintSense
+    """
+    Sense of the constraint, must be lower equal/<= (ConstraintSense.LE),
+    equal/== (ConstraintSense.EQ) or greater equal/>= (ConstraintSense.GEQ).
+    """
+
+
+@dataclass
+class IndicatorConstraint(Constraint):
+    """
+    A constraint which is only active if its associated binary variable
+    (with the name binary_name) has a certain given value (binary_value).
+    E.g., if we want the following constraint...
+
+    A <= 5
+
+    ...to be only active when the value of a binary variable B is 0, i.e.,
+
+    B=0 -> A <= 5,
+
+    then binary_name is 'B' and binary_value is 0. For more about the other
+    member variables taken over from the usual Constraint class, see their
+    description directly.
+    """
+
+    binary_name: str
+    """The name of the binary variable which controls this indicator constraint."""
+    binary_value: BinaryValue
+    """
+    The value of the binary_name-defined binary variable at which the given
+    constraint must be fulfilled.
+    """
+
+
+@dataclass
+class Objective:
+    """
+    A (MI)LP objective function defined by its vector
+    and with a given direction (minimization or maximization).
+    """
+
+    vector: Dict[str, float]
+    """
+    The definition of the constituents of the objective's terms. I.e., if we
+    want to optimize...
+
+    2 A + 3 B ...
+
+    then our vector is...
+
+    {"A": 2.0, "B": 3.0}.
+    """
+    direction: ObjectiveDirection
+    """
+    The objective's direction, either minimization (ObjectiveDirection.MAX)
+    or maximization (ObjectiveDirection.MIN) of the term in the objective's vector.
+    """
+
+
+@dataclass
+class Result:
+    """Contains all relevant information about the result of an optimization."""
+
+    status: Status
+    """Indicated whether or not an optimal solution was found (Status.OPTIMAL) or not (any other Status value)."""
+    objective_value: float
+    """The result's objective value, already corrected for maximization or minimization."""
+    values: Dict[str, float]
+    """The single solution variable values as a dict with the variable names as key."""
+
+
+# MAIN CLASS SECTION #
+class LinearProgram:
+    """
+    Main class of StrainDesign's class interface.
+
+    It contains the full description of a (mixed-integer) linear program, i.e., its variables, constraints
+    and objective.
+
+    # Variables
+
+    Variables are separated as continuous *float* variables (which can take up continuous values, e.g. -1.2 or 3.0) and
+    *binary* variables (which can be only either 0 or 1). Float variables are of the class FloatVariable, binary variables
+    of BinaryVariable.
+
+    Variables must have a unique name (i.e., no two variables must
+    have the same name) and can be included in the LinearProgram as an already existing FloatVariable or BinaryVariable
+    instance through add_existing_float_variable() or add_existing_binary_variable, or as newly described variable
+    with add_float_variable() or add_binary_variable().
+
+    # Constraints
+
+    Constraints can be of the form 'Expression <= Number' (e.g., 2 A + B <= -1), 'Expression == Number' (e.g., A + B = 1)
+    or 'Expression >= Number' (e.g., A + 2 B >= 4).
+
+    They are separated as 'normal' constraints or 'indicator' constraints.
+    Both can be defined using FloatVariable and BinaryVariable instance names for their left-hand side and a float for their
+    right-hand side. The difference is that an indicator constraint is only active (i.e., it only plays a role) if and only
+    if a selected binary value is one of 0 or 1. E.g., the indicator constraint T=0 → A <= 1 means that A must be smaller than
+    1 only and only if the binary variable T is zero.
+
+    Normal constraints are of the class Constraint, indicator constraint of IndicatorConstraint.
+
+    # Objective
+
+    # Solving a LinearProgram
+    """
+
+    def __init__(self) -> None:
+        self.float_variables: Dict[str, FloatVariable] = {}
+        self.binary_variables: Dict[str, BinaryVariable] = {}
+        self.constraints: Dict[str, Constraint] = {}
+        self.indicator_constraints: Dict[str, IndicatorConstraint] = {}
+        self.timelimit: int = 30
+        self.objective: Objective = Objective(
+            vector={},
+            direction=ObjectiveDirection.MAX,
+        )
+
+    def _get_objective_vector(self) -> List[float]:
+        objective_vector = [0.0 for _ in range(self.num_variables)]
+        if self.objective.direction == ObjectiveDirection.MAX:
+            multiplier = -1
+        else:
+            multiplier = 1
+        for var_name, coeff in self.objective.vector.items():
+            objective_vector[self.active_variables.index(var_name)] = multiplier * coeff
+        return objective_vector
+
+    def add_binary_variable(self, name: str) -> None:
+        new_variable = BinaryVariable(
+            name=name,
+        )
+        self.binary_variables[name] = new_variable
+
+    def add_constraint(
+        self,
+        name: str,
+        lhs: Dict[str, float],
+        sense: ConstraintSense,
+        rhs: float,
+    ) -> None:
+        constraint = Constraint(
+            name=name,
+            lhs=lhs,
+            rhs=rhs,
+            sense=sense,
+        )
+        self.add_existing_constraint(constraint)
+
+    def add_existing_binary_variable(self, variable: BinaryVariable) -> None:
+        self.binary_variables[variable.name] = variable
+
+    def add_existing_constraint(self, constraint: Constraint) -> None:
+        self.constraints[constraint.name] = constraint
+
+    def add_existing_float_variable(self, variable: FloatVariable) -> None:
+        self.float_variables[variable.name] = variable
+
+    def add_existing_indicator_constraint(
+        self, indicator_constraint: IndicatorConstraint
+    ) -> None:
+        self.indicator_constraints[indicator_constraint.name] = indicator_constraint
+
+    def add_float_variable(self, name: str, lb: float, ub: float) -> None:
+        new_variable = FloatVariable(
+            name=name,
+            lb=lb,
+            ub=ub,
+        )
+        self.float_variables[name] = new_variable
+
+    def add_indicator_constraint(
+        self,
+        name: str,
+        lhs: Dict[str, float],
+        rhs: float,
+        sense: ConstraintSense,
+        binary_name: str,
+        binary_value: BinaryValue,
+    ) -> None:
+        self.indicator_constraints[name] = IndicatorConstraint(
+            name=name,
+            lhs=lhs,
+            rhs=rhs,
+            sense=sense,
+            binary_name=binary_name,
+            binary_value=binary_value,
+        )
+
+    def add_lhs_bound_variable(self, var_name: str, lhs: Dict[str, float]) -> None:
+        self.add_float_variable(name=var_name, lb=-float("inf"), ub=float("inf"))
+        lhs[var_name] = -1
+        self.add_constraint(
+            name=f"Bound var {var_name} to rest of this LHS",
+            lhs=lhs,
+            rhs=0,
+            sense=ConstraintSense.EQ,
+        )
+
+    def add_linear_function_approximation(
+        self,
+        existing_x_var: str,
+        new_y_var: str,
+        function_to_approximate: Callable[[float], float],
+        function_derivative: Callable[[float], float],
+        min_x: float,
+        max_x: float,
+        max_relative_error: float,
+        is_minimum_for_y: bool,
+    ) -> None:
+        current_num_sections = 2
+        is_above_error = True
+        while is_above_error:
+            section_xs = linspace(min_x, max_x, current_num_sections)
+            step_size = section_xs[1] - section_xs[0]
+            is_above_error = False
+            linear_approximations: List[Tuple[float, float]] = []
+            current_section_x = 0
+            for section_x in section_xs:
+                function_y = function_to_approximate(section_x)
+                derivative_y = function_derivative(section_x)
+                m_value = derivative_y
+                b_value = function_y - derivative_y * section_x
+
+                if current_section_x == 0:
+                    left_x = section_x
+                else:
+                    left_x = section_x - step_size / 2
+                if current_section_x == (len(section_xs) - 1):
+                    right_x = section_x
+                else:
+                    right_x = section_x + step_size / 2
+
+                for test_x in (left_x, right_x):
+                    try:
+                        function_y = function_to_approximate(test_x)
+                    except ValueError:
+                        continue
+                    approximation_y = m_value * test_x + b_value
+                    error_absolute = function_y - approximation_y
+                    error_relative = abs(error_absolute / function_y)
+                    if error_relative > max_relative_error:
+                        is_above_error = True
+                        break
+
+                if is_above_error:
+                    current_num_sections += 1
+                    break
+
+                linear_approximations.append((m_value, b_value))
+                current_section_x += 1
+
+        self.add_float_variable(
+            name=new_y_var,
+            lb=-float("inf"),
+            ub=float("inf"),
+        )
+        current_approx = 0
+        for linear_approximation in linear_approximations:
+            m_value = linear_approximation[0]
+            b_value = linear_approximation[1]
+            if is_minimum_for_y:
+                #     y_variable >= m_value * x_variable + b_value
+                # <=> -y_variable + m_value * x_variable <= -b_value
+                multiplier = 1
+            else:
+                #     y_variable <= m_value * x_variable + b_value
+                # <=> y_variable - m_value * x_variable <= b_value
+                multiplier = -1
+            self.add_constraint(
+                name=f"Function approximation no. {current_approx} through "
+                f"{new_y_var} from {existing_x_var}",
+                lhs={
+                    new_y_var: -multiplier,
+                    existing_x_var: m_value * multiplier,
+                },
+                rhs=-multiplier * b_value,
+                sense=ConstraintSense.EQ,
+            )
+            current_approx += 1
+
+    def construct_solver_object(
+        self,
+        big_m_value: Union[None, float, int] = None,
+        skip_checks: bool = True,
+        timelimit: Union[int, None] = None,
+        solver: Solver = Solver.GLPK,
+    ) -> None:
+        # Pre-creation of data structures which will be used in the following steps
+        active_variables: List[str] = []
+        eq_names: List[str] = []
+        ineq_names: List[str] = []
+        num_equalities = 0
+        num_inequalities = 0
+        get_var_names = lambda constraint_dict: [
+            var_name for var_name in constraint_dict.keys()
+        ]
+        for constraint in self.constraints.values():
+            active_variables += get_var_names(constraint.lhs)
+            if constraint.sense == ConstraintSense.EQ:
+                num_equalities += 1
+                eq_names.append(constraint.name)
+            else:
+                num_inequalities += 1
+                ineq_names.append(constraint.name)
+        for indicator_constraint in self.indicator_constraints.values():
+            active_variables += get_var_names(indicator_constraint.lhs)
+            active_variables += [indicator_constraint.binary_name]
+        active_variables = list(set(active_variables))
+        num_variables = len(active_variables)
+        self.active_variables = active_variables
+        self.num_variables = num_variables
+
+        # Build A and b
+        num_matrix_columns = num_variables
+        A_ineq = sparse.lil_matrix((num_inequalities, num_matrix_columns))
+        b_ineq: List[float] = [0.0 for _ in range(num_inequalities)]
+        ineq_index = 0
+        for ineq_name in ineq_names:
+            constraint = self.constraints[ineq_name]
+            row = ineq_names.index(constraint.name)
+            if constraint.sense == ConstraintSense.GEQ:
+                multiplier = -1.0
+            else:
+                multiplier = 1.0
+            for var_name, coeff in constraint.lhs.items():
+                column = active_variables.index(var_name)
+                A_ineq[row, column] = coeff * multiplier
+            b_ineq[ineq_index] = self.constraints[ineq_name].rhs * multiplier
+            ineq_index += 1
+        A_ineq = sparse.csr_matrix(A_ineq)
+
+        A_eq = sparse.lil_matrix((num_equalities, num_matrix_columns))
+        for eq_name in eq_names:
+            constraint = self.constraints[eq_name]
+            row = eq_names.index(constraint.name)
+            for var_name, coeff in constraint.lhs.items():
+                column = active_variables.index(var_name)
+                A_eq[row, column] = coeff
+        A_eq = sparse.csr_matrix(A_eq)
+        b_eq: List[float] = [self.constraints[eq_name].rhs for eq_name in eq_names]
+
+        # Build LB and UB vectors
+        num_bounded_variables = len(active_variables)
+        lower_bounds: List[float] = [0.0 for _ in range(num_bounded_variables)]
+        upper_bounds: List[float] = [0.0 for _ in range(num_bounded_variables)]
+        variable_types: str = ""
+        var_index = 0
+        for var_name in active_variables:
+            if var_name in self.binary_variables.keys():
+                lb = 0.0
+                ub = 1.0
+                variable_types += "B"
+            else:
+                float_var = self.float_variables[var_name]
+                lb = float_var.lb
+                ub = float_var.ub
+                variable_types += "C"
+            lower_bounds[var_index] = lb
+            upper_bounds[var_index] = ub
+            var_index += 1
+
+        # Build objective vector
+        objective_vector: List[float] = self._get_objective_vector()
+
+        # Create indicator constraints
+        binv: List[int] = []  # Binary variable indices
+        # Set coeffs of indicators; num_rows = number of indicator constraints,
+        # num_columns = number of variables
+        A_indic = sparse.lil_matrix(
+            (len(self.indicator_constraints), num_matrix_columns)
+        )
+        b_indic: List[float] = [
+            0.0 for _ in range(len(self.indicator_constraints.values()))
+        ]  # RHS of indicators
+        sense = ""
+        # Indicval which binary value activates indicator constraint
+        indicval: List[int] = [
+            0 for _ in range(len(self.indicator_constraints.values()))
+        ]
+        indic_index = 0
+        for indicator_constraint in self.indicator_constraints.values():
+            binary_name = indicator_constraint.binary_name
+            binv.append(active_variables.index(binary_name))
+
+            for var_name, coeff in indicator_constraint.lhs.items():
+                A_indic[indic_index, active_variables.index(var_name)] = coeff
+
+            b_indic[indic_index] = indicator_constraint.rhs
+
+            if sense == ConstraintSense.EQ:
+                sense += "E"
+            else:
+                sense += "L"
+
+            if indicator_constraint.binary_value == BinaryValue.ZERO:
+                indicval[indic_index] = 0
+            else:
+                indicval[indic_index] = 1
+
+            indic_index += 1
+        A_indic = sparse.csr_matrix(A_indic)
+
+        if len(indicval) > 0:
+            indicator_constraints = IndicatorConstraints(
+                binv=binv,
+                A=A_indic,
+                b=b_indic,
+                sense=sense,
+                indicval=indicval,
+            )
+        else:
+            indicator_constraints = None
+
+        # Generate StrainDesign object
+        self._milp_lp = MILP_LP(
+            c=objective_vector,
+            A_ineq=A_ineq,
+            b_ineq=b_ineq,
+            A_eq=A_eq,
+            b_eq=b_eq,
+            lb=lower_bounds,
+            ub=upper_bounds,
+            vtype=variable_types,
+            indic_constr=indicator_constraints,
+            M=big_m_value,
+            solver=solver.value,
+            skip_checks=skip_checks,
+            tlim=timelimit,
+        )
+
+
+    def delete_binary_variable(self, name: str) -> None:
+        del self.binary_variables[name]
+
+    def delete_float_variable(self, name: str) -> None:
+        del self.float_variables[name]
+
+    def delete_constraint(self, name: str) -> None:
+        del self.constraints[name]
+
+    def run_populate(self, num: int) -> Tuple[List[List[float]], List[float], float]:
+        solvecs, optvals, optstatuses = self._milp_lp.populate(num)
+        return solvecs, optvals, optstatuses
+
+    def run_slim_solve(self) -> float:
+        optval = self._milp_lp.slim_solve()
+        return self._set_optval_according_to_sense(optval)
+
+    def _get_status_enum(self, status: str) -> Status:
+        if status == "optimal":
+            return Status.OPTIMAL
+        elif status == "unbounded":
+            return Status.UNBOUNDED
+        elif status == "time_limit":
+            return Status.TIME_LIMIT
+        elif status == "infeasible":
+            return Status.INFEASIBLE
+        else:
+            return Status.UNKNOWN
+
+    def run_solve(self) -> Result:
+        solvec, optval, optstatus = self._milp_lp.solve()
+        resultdict: Dict[str, float] = {}
+        i = 0
+        for active_variable in self.active_variables:
+            resultdict[active_variable] = solvec[i]
+            i += 1
+        optstatus_str = str(optstatus)
+        return Result(
+            status=self._get_status_enum(optstatus_str),
+            objective_value=self._set_optval_according_to_sense(optval),
+            values=resultdict,
+        )
+
+    def _set_optval_according_to_sense(self, optval: float) -> float:
+        if self.objective.direction == ObjectiveDirection.MAX:
+            return -optval
+        else:
+            return optval
+
+    def set_existing_objective(self, objective: Objective, warmstart=False) -> None:
+        self.objective = objective
+        if warmstart:
+            self._milp_lp.set_objective(self._get_objective_vector())
+
+    def set_objective(
+        self,
+        vector: Dict[str, float],
+        direction: ObjectiveDirection,
+        warmstart=False,
+    ) -> None:
+        self.objective = Objective(
+            vector=vector,
+            direction=direction,
+        )
+        if warmstart:
+            self._milp_lp.set_objective(self._get_objective_vector())
+
+    def set_single_variable_objective(
+        self, var_name: str, direction: ObjectiveDirection, warmstart=False
+    ) -> None:
+        self.objective = Objective(
+            vector={var_name: 1},
+            direction=direction,
+        )
+        if warmstart:
+            self._milp_lp.set_objective(self._get_objective_vector())
+
+    # def run_variability_analysis(
+    #     self, varnames: List[str] = []
+    # ) -> List[Tuple[str, float, float]]:
+    #     if varnames == []:
+    #         varnames = self.active_variables
+    #     del self._milp_lp
+    #     num_cpus = cpu_count()
+    #     if num_cpus is None:
+    #         num_cpus = 1
+    #     num_processes = min(len(varnames), num_cpus)
+    #     varname_chunks = [
+    #         [str(y) for y in x] for x in array_split(varnames, num_processes)
+    #     ]
+    #     futures = [
+    #         variability_calc.remote(self, varname_chunk)
+    #         for varname_chunk in varname_chunks
+    #     ]
+    #     results = ray.get(futures)
+    #     return results
+
+
+# @ray.remote
+# def variability_calc(
+#     lp_object: LinearProgram, varnames: List[str]
+# ) -> List[Tuple[str, float, float]]:
+#     ray.init(log_to_driver=False)
+#     lp_object.construct_solver_object(solver=Solver.CPLEX)
+#     result = []
+#     for varname in varnames:
+#         lp_object.set_single_variable_objective(
+#             varname, direction=ObjectiveDirection.MIN, warmstart=True
+#         )
+#         min_value = lp_object.run_slim_solve()
+#         lp_object.set_single_variable_objective(
+#             varname, direction=ObjectiveDirection.MAX, warmstart=True
+#         )
+#         max_value = lp_object.run_slim_solve()
+#         result.append((varname, min_value, max_value))
+#     return result
+
+
+"""
+# R1: -> A
+# R2: 4 A -> B
+# R3: B ->
+# ...and a test indicator constraint
+testlp = LinearProgram()
+
+var_R1 = FloatVariable("R1", 0, 12)
+var_R2 = FloatVariable("R2", 0, 100)
+var_R3 = FloatVariable("R3", 2, 2)
+
+testlp.add_existing_float_variable(var_R1)
+testlp.add_existing_float_variable(var_R2)
+testlp.add_existing_float_variable(var_R3)
+
+testlp.add_binary_variable("B1")
+indicator = IndicatorConstraint(
+    name="Indicator 1",
+    lhs={"R1": -1},
+    rhs=0,
+    sense=ConstraintSense.LEQ,
+    binary_name="B1",
+    binary_value=BinaryValue.ZERO,
+)
+testlp.add_existing_indicator_constraint(indicator)
+
+testlp.add_constraint(
+    name="Steady-state of A",
+    lhs={"R1": 1, "R2": -4},
+    rhs=0,
+    sense=ConstraintSense.EQ,
+)
+testlp.add_constraint(
+    name="Steady-state of B",
+    lhs={"R2": 1, "R3": -1},
+    rhs=0,
+    sense=ConstraintSense.EQ,
+)
+testlp.objective = Objective(
+    vector={"B1": 1},
+    direction=ObjectiveDirection.MIN,
+)
+testlp.construct_solver_object(solver=Solver.CPLEX)
+print(testlp.run_slim_solve())
+new_obj = Objective(
+    vector={"B1": 1},
+    direction=ObjectiveDirection.MAX,
+)
+testlp.set_existing_objective(new_obj, warmstart=True)
+# print(testlp.run_slim_solve())
+# testlp.run_variability_analysis()
+
+cobra_model = cobra.io.read_sbml_model("ECC2.xml")
+print("COBRApy:", cobra_model.objective, cobra_model.slim_optimize())
+lp = get_steady_state_lp_from_cobra_model(cobra_model=cobra_model)
+lp.objective = Objective(
+    vector={"Ec_biomass_iJO1366_core_53p95M": 1.0},
+    direction=ObjectiveDirection.MAX,
+)
+lp.construct_solver_object(solver=Solver.CPLEX)
+solve_result = lp.run_solve()
+json_write("x.json", solve_result.values)
+print("Result with Class Interface:", lp.run_slim_solve())
+
+variable_names = list(solve_result.values.keys())
+lp.run_variability_analysis(variable_names)
+
+
+input("X")
+cobra_model = cobra.io.read_sbml_model("astheriscToymodelDouble_irreversible.xml")
+cobra_model.reactions.get_by_id("EXCHG_strain1_B_c_to_B_FWD").upper_bound = float("inf")
+cobra_model.reactions.get_by_id("EXCHG_strain2_B_c_to_B_REV").upper_bound = float("inf")
+
+dG0_values = json_load("dG0_astheriscToymodelDouble.json")
+for key in [x for x in dG0_values.keys()]:
+    dG0_values[key + "_FWD"] = dG0_values[key]
+    dG0_values[key + "_REV"] = dG0_values[key]
+
+concentration_values = {
+    "DEFAULT": {
+        "min": 1.0,
+        "max": 10.0,
+    },
+    "P_exchg": {
+        "min": 5.0,
+        "max": 10.0,
+    },
+}
+extra_constraints = [
+    {
+        "EX_C_P_exchg_FWD": 1.0,
+        "ub": 1.0,
+        "lb": 1.0,
+    }
+]
+optmdf = create_optmdfpathway_milp(
+    cobra_model=cobra_model,
+    dG0_values=dG0_values,
+    concentration_values=concentration_values,
+    extra_constraints=extra_constraints,
+)
+optmdf.objective = Objective(
+    vector={"var_B": 1.0},
+    direction=ObjectiveDirection.MAX,
+)
+optmdf.construct_solver_object(solver=Solver.CPLEX)
+solve_result = optmdf.run_solve()
+json_write("x.json", solve_result.values)
+print("OPTMDF", optmdf.run_slim_solve())
+optmdf.set_single_variable_objective(
+    "x_P_exchg", direction=ObjectiveDirection.MAX, warmstart=True
+)
+print("x_P_exchg", exp(optmdf.run_slim_solve()))
+optmdf.set_single_variable_objective(
+    "x_P_exchg", direction=ObjectiveDirection.MIN, warmstart=True
+)
+print("x_P_exchg", exp(optmdf.run_slim_solve()))
+print("x_P_exchg", exp(optmdf.run_slim_solve()))
+solve_result = optmdf.run_solve()
+json_write("x2.json", solve_result.values)
+"""

--- a/cnapy/sd_class_interface.py
+++ b/cnapy/sd_class_interface.py
@@ -7,9 +7,11 @@ from dataclasses import dataclass
 from enum import Enum
 from os import cpu_count
 from numpy import array_split, linspace
+
 # import ray
 from scipy import sparse
 from typing import Any, Callable, Dict, List, Tuple, Union
+
 # from helper import json_write, json_load
 
 # Internal packages
@@ -582,7 +584,6 @@ class LinearProgram:
             skip_checks=skip_checks,
             tlim=timelimit,
         )
-
 
     def delete_binary_variable(self, name: str) -> None:
         del self.binary_variables[name]


### PR DESCRIPTION
# Welcome to a new world 🌍🌎🌏

Up to now, life seems bleak. Something is out of place, right? Ok, you go to parties and other events. But afterwards, everything feels like before. This nasty feeling that there is a hole in your soul. No problem, you say, that can be fixed! So you travel around the globe. But again, after everything that you've experienced, your soul feels empty. Whatever you do, something is *missing*.

But now, this *something* has arrived, finally, your life is complete, at last!

# Introducing...

![Visual_OptMDFpathway](https://user-images.githubusercontent.com/36934614/207812930-66a6127a-9ab6-4eab-93fe-a7d31592dcd6.gif)

Yes, it has arrived! [OptMDFpathway ](https://doi.org/10.1371/journal.pcbi.1006492) in its basic form is now included *inside* CNApy 🎇🎆

# Wow! So how does this major achievement work internally?

Programmatically, I wrote a new "class interface" for [StrainDesign](https://github.com/klamt-lab/straindesign), currently, you can find it as "sd_class_interface.py" in CNApy but it will likely be released as a separate package in the future. This interface allows one to use StrainDesign in an object-oriented and strictly typed (as far as possible with Python) manner.

Then, I implemented OptMDFpathway using this class interface and with indicator constraints (contrary to prior Big-M-based implementations). It can be found as "sd_ci_optmdfpathway.py", which, again, will be likely part of the future new package. In fact, this is an OptMDFpathway implementation for models with *irreversible* reactions. Therefore, if the CNApy model contains reversible reactions, they are split first internally but without any effect on the user's model after the calculation.

# Even more wow! And how do I use it in CNApy?

You can find all options for starting OptMDFpathway and loading its relevant information in the marked new "Analysis" tab menu entries:

![In_menu](https://user-images.githubusercontent.com/36934614/207814909-ffa2b9ee-4e35-4cd1-b943-242a0c64f22c.png)

Before you can start OptMDFpathway for a CNApy project, you need the following data:

* Gibbs free energies (dG'°) in kJ/mol: At least one reaction needs this, otherwise, OptMDFpathway cannot work. You can add the dG'° either A) manually by adding an annotation with the key 'dG0' and the dG'° as value, B) loading a JSON with the relevant data as given in the appendix of this message or C) loading an XLSX with the data as given in the test suite later. You an also set an optional dG'° uncertainty with the key 'dG0_uncertainty', which can also be included in the JSON and XLSX files.

* Concentration ranges in M: Every metabolite of the project needs a minimal (Cmin) and maximal (Cmax) concentration, otherwise, OptMDFpathway cannot work. You can add the concentration ranges either A) manually by adding annotations with the key 'Cmin' and 'Cmax' and the associated concentration as value, B) loading a JSON with the relevant data as given in the appendix of this message or C) loading an XLSX with the data as given in the test suite later. Using options B and C, you can easily set a concentration for all metabolites by defining a 'DEFAULT' concentration range.

Note that whenever you load a dG'° or concentration ranges file, these values will completely *replace* all values beforehand. E.g., if a dG'° was set for a reaction beforehand but it is not set in the file, the reaction will not have a dG'° afterwards.

Furthermore, while XLSX files need a title in their first line, the text content of these captions is actually irrelevant.

Then, you can start the calculation which can be performed with all StrainDesign-supported solvers, just keep in mind that with GLPK, the indicator constraints will be transformed into Big-M constraints as indicators are not supported by GLPK.

# I'm so hyped now! How can I test it?

Attached, you may find (as zipped version of them)...

1. [[ASTHERISC_OptMDF_toymodel.zip (Download by clicking here)](https://github.com/cnapy-org/CNApy/files/10235428/ASTHERISC_OptMDF_toymodel.zip)] an adaptation of my [ASTHERISC ](https://github.com/klamt-lab/astheriscPackage) toy model with already loaded dG'° values and concentration ranges. It should result in an OptMDF of ca. -0.19 kJ/mol.
2. [[ASTHERISC_toymodel.zip](https://github.com/cnapy-org/CNApy/files/10235471/ASTHERISC_toymodel.zip)] The ASTHERISC toymodel *without* dG'° and metabolite concentration values.
3. [[dG0s_xlsx.zip](https://github.com/cnapy-org/CNApy/files/10235667/dG0s_xlsx.zip)] A dG'° XLSX for the ASTHERISC toymodel.
4. [[dG0s_json.zip](https://github.com/cnapy-org/CNApy/files/10235602/dG0s_json.zip)] A dG'° JSON for the ASTHERISC toymodel
5. [[concentrations_xlsx.zip](https://github.com/cnapy-org/CNApy/files/10235511/concentrations_xlsx.zip)] A concentration ranges XLSX for the ASTHERISC toymodel.
6. [[concentration_values_json.zip](https://github.com/cnapy-org/CNApy/files/10235513/concentration_values_json.zip)] A concentration ranges JSON for the ASTHERISC toymodel.

# I want to exploit the hype generated by this pull request! Will there be a VisualOptMDF coin? Can I buy the Visual OptMDFpathway logo as NFT?

No.