### PR TITLE
Add menu entry for storing reaction list content

### DIFF
--- a/cnapy/gui_elements/reactions_list.py
+++ b/cnapy/gui_elements/reactions_list.py
@@ -486,9 +486,7 @@ class ReactionList(QWidget):
         action.triggered.connect(self.copy_to_clipboard)
         menu.exec_(self.reaction_list.header().mapToGlobal(position))
 
-    @Slot()
-    def copy_to_clipboard(self):
-        clipboard = QGuiApplication.clipboard()
+    def get_as_table(self) -> str:
         visible_columns = [j.value for j in ReactionListColumn if not self.reaction_list.isColumnHidden(j)]
         table = ["\t".join([ReactionListColumn(j).name for j in visible_columns])]
         root = self.reaction_list.invisibleRootItem()
@@ -499,7 +497,13 @@ class ReactionList(QWidget):
             for j in visible_columns:
                 line.append(item.text(j))
             table.append("\t".join(line))
-        clipboard.setText("\r".join(table))
+        return "\r".join(table)
+
+    @Slot()
+    def copy_to_clipboard(self):
+        clipboard = QGuiApplication.clipboard()
+        table = self.get_as_table()
+        clipboard.setText(table)
 
     itemActivated = Signal(str)
     reactionChanged = Signal(str, cobra.Reaction)

--- a/environment.yml
+++ b/environment.yml
@@ -27,3 +27,4 @@ dependencies:
   - gurobi
   - cplex
   - numpy<1.24
+  - openpyxl

--- a/recipes/linux/meta.yaml
+++ b/recipes/linux/meta.yaml
@@ -36,6 +36,7 @@ requirements:
     - gurobi
     - cplex
     - numpy<1.24
+    - openpyxl
 
 build:
   number: 0  # NOTE: increment for new build/set to zero for new version

--- a/recipes/noarch/meta.yaml
+++ b/recipes/noarch/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - gurobi
     - cplex
     - numpy<1.24
+    - openpyxl
 
 build:
   noarch: python

--- a/recipes/win/meta.yaml
+++ b/recipes/win/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - gurobi
     - cplex
     - numpy<1.24
+    - openpyxl
 
 build:
   number: 0  # NOTE: increment for new build/set to zero for new version


### PR DESCRIPTION
This one obsoletes #437 and is now basically just an easier-to-find reaction list clipboard saving menu entry (thanks to @axelvonkamp's addition) as CSV or XLSX.