### PR TITLE
Add new installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,40 +46,37 @@ Aside of performing calculations on metabolic models, CNApy can also be used to 
 
 ## Installation Options
 
-There are 3 ways to install CNApy:
+There are 4 alternative ways to install CNApy:
 
-1. The easiest installation option under Windows, Linux and MacOS is our assisted installation protocol which you can find in section [Assisted CNApy installation](#assisted-cnapy-installation).
-2. If you already have installed Anaconda or Miniconda on your computer, you can directly install CNApy as a conda package as described in section [Install CNApy as conda package](#install-cnapy-as-conda-package).
-3. If you want to develop CNApy, follow the instruction for the cloning and set-up of the CNApy repository using git and conda in section [Setup the CNApy development environment](#setup-the-cnapy-development-environment).
+1. If you use Windows, the easiest way is to use our Windows installer, see section [Using the Windows installer](#using-the-windows-installer).
+2. If you use Linux or Apple MacOS X, the easiest installation producure is our assisted installation protocol, see [Assisted installation under Linux and MacOS X](#assisted-installation-under-linux-and-macos-x).
+3. If you already have installed Anaconda or Miniconda on your computer, you can directly install CNApy as a conda package as described in section [Install CNApy as conda package](#install-cnapy-as-conda-package).
+4. If you want to develop CNApy, follow the instruction for the cloning and set-up of the CNApy repository using git and conda in section [Setup the CNApy development environment](#setup-the-cnapy-development-environment).
 
 ## Contribute to the CNApy development
 
 Everyone is welcome to contribute to CNApy's development. [See our contribution file for more detailed instructions](https://github.com/cnapy-org/CNApy/blob/master/CONTRIBUTING.md).
 
-## Assisted CNApy installation
+## Using the Windows installer
+
+1. Download the zipped CNApy Windows installer [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-windows-installer.zip).
+2. Unzip the file into your desired location. You can do this by right-clicking on the file and selecting the option to extract the files.
+3. In the location where you unzipped the file, click on "INSTALL_CNAPY.bat". As soon as the installation is finished, the appearing window closes and you can start CNApy either by double-clicking on the newly created CNApy desktop icon or by searching for CNApy through the task bar search.
+
+## Assisted installation under Linux and MacOS X
 
 Click on the operating system you use:
 
-- [Windows](#windows-installation)
-- [Linux](#linux-installation)
-- [MacOS X](#macos-x-installation)
+- [Linux](#assisted-linux-installation)
+- [Apple MacOS X](#assisted-macos-x-installation)
 
-### Windows installation
-
-1. Download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe).
-2. Install Miniconda by double-clicking the downloaded file. Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
-3. Using the File Explorer, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
-4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.bat) into the mentioned "condabin" folder.
-5. In the file explorer, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.bat". Wait until CNApy is downloaded and installed.
-6. You can now start CNApy by either double-clicking on the newly created CNApy icon on your desktop, or by searching for "CNApy" using the search feature of the task bar.
-
-### Linux installation
+### Assisted Linux installation
 
 1. Download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh).
-2. Install Miniconda by double-clicking the downloaded file. If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./Miniconda3-latest-Linux-x86_64.sh' in your terminal). Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
+2. Install Miniconda by double-clicking the downloaded file. If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./Miniconda3-latest-Linux-x86_64.sh' in your terminal). Follow the appearing installation instructions and remember in which folder you install Miniconda. If you already use Anaconda on your computer (for which we also directly provide a conda CNApy package, [see here](#install-cnapy-as-conda-package)), deactivate all installation options which put Miniconda to your console or system PATH to avoid possible problems.
 3. Using your file manager, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
-4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.sh) into the mentioned "condabin" folder.
-5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-installation-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
+4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-assistant-script.sh) into the mentioned "condabin" folder.
+5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-assistant-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-assistant-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
 6. You can now run CNApy by executing the following two terminal instructions in the mentioned "condabin" folder:
 
 ```sh
@@ -87,13 +84,13 @@ Click on the operating system you use:
 cnapy
 ```
 
-### MacOS X installation
+### Assisted MacOS X installation
 
-1. If you have a (new) Mac with an ARM processor, such as the M1 or M2, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg). If you have an (older) Mac with an Intel processor, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg).
-2. Install Miniconda by double-clicking the downloaded file. Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
+1. If you have a (new) Mac with an ARM processor, such as the M1 or M2, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg). If you have an (older) Mac with an Intel processor, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg). If you are unsure which processor your Mac has, click on the Apple menu in the upper-left of your screen and choose "About This Mac".
+2. Install Miniconda by double-clicking the downloaded file. Follow the appearing installation instructions and remember in which folder you install Miniconda. If you already use Anaconda on your computer (for which we directly provide a conda CNApy package, [see here](#install-cnapy-as-conda-package)), deactivate all installation options which put Miniconda to your console or system PATH to avoid possible problems
 3. Using Finder, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
-4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.sh) into the mentioned "condabin" folder.
-5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-installation-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
+4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-assistant-script.sh) into the mentioned "condabin" folder.
+5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-assistant-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
 6. Open the terminal in the mentioned "condabin" folder. You can now run CNApy by executing the following two terminal instructions:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -40,46 +40,82 @@ Aside of performing calculations on metabolic models, CNApy can also be used to 
 
 ## Documentation and Tutorials
 
-* The [CNApy guide](https://cnapy-org.github.io/CNApy-guide/) contains information for all major functions of CNApy.
-* Our [CNApy YouTube channel](https://www.youtube.com/channel/UCRIXSdzs5WnBE3_uukuNMlg) provides some videos of working with CNApy.
-* We also provide directly usable [CNApy example projects](https://github.com/cnapy-org/CNApy-projects/releases/latest) which include some of the most common *E. coli* models. These projects can also be downloaded within CNApy at its first start-up or via CNApy's File menu.
+- The [CNApy guide](https://cnapy-org.github.io/CNApy-guide/) contains information for all major functions of CNApy.
+- Our [CNApy YouTube channel](https://www.youtube.com/channel/UCRIXSdzs5WnBE3_uukuNMlg) provides some videos of working with CNApy.
+- We also provide directly usable [CNApy example projects](https://github.com/cnapy-org/CNApy-projects/releases/latest) which include some of the most common *E. coli* models. These projects can also be downloaded within CNApy at its first start-up or via CNApy's File menu.
 
 ## Installation Options
 
-There are three ways to install CNApy:
+There are 3 ways to install CNApy:
 
-1. As the easiest installation way which only works under Windows, you can use the .exe installer attached to the assets at the bottom of [CNApy's latest release](https://github.com/cnapy-org/CNApy/releases/latest).
-2. Under any operating system, you can install CNApy as a conda package as described in section [Install CNApy as conda package](#install-cnapy-as-conda-package).
-3. If you want to develop CNApy, follow the instruction for the successful cloning of CNApy in section [Setup the CNApy development environment](#setup-the-cnapy-development-environment).
+1. The easiest installation option under Windows, Linux and MacOS is our assisted installation protocol which you can find in section [Assisted CNApy installation](#assisted-cnapy-installation).
+2. If you already have installed Anaconda or Miniconda on your computer, you can directly install CNApy as a conda package as described in section [Install CNApy as conda package](#install-cnapy-as-conda-package).
+3. If you want to develop CNApy, follow the instruction for the cloning and set-up of the CNApy repository using git and conda in section [Setup the CNApy development environment](#setup-the-cnapy-development-environment).
 
 ## Contribute to the CNApy development
 
 Everyone is welcome to contribute to CNApy's development. [See our contribution file for more detailed instructions](https://github.com/cnapy-org/CNApy/blob/master/CONTRIBUTING.md).
 
+## Assisted CNApy installation
+
+Click on the operating system you use:
+
+- [Windows](#windows-installation)
+- [Linux](#linux-installation)
+- [MacOS X](#macos-x-installation)
+
+### Windows installation
+
+1. Download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe).
+2. Install Miniconda by double-clicking the downloaded file. Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
+3. Using the File Explorer, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
+4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.bat) into the mentioned "condabin" folder.
+5. In the file explorer, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.bat". Wait until CNApy is downloaded and installed.
+6. You can now start CNApy by either double-clicking on the newly created CNApy icon on your desktop, or by searching for "CNApy" using the search feature of the task bar.
+
+### Linux installation
+
+1. Download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh).
+2. Install Miniconda by double-clicking the downloaded file. If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./Miniconda3-latest-Linux-x86_64.sh' in your terminal). Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
+3. Using your file manager, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
+4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.sh) into the mentioned "condabin" folder.
+5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-installation-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
+6. You can now run CNApy by executing the following two terminal instructions in the mentioned "condabin" folder:
+
+```sh
+./conda activate cnapy-1.1.6
+cnapy
+```
+
+### MacOS X installation
+
+1. If you have a (new) Mac with an ARM processor, such as the M1 or M2, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.pkg). If you have an (older) Mac with an Intel processor, download Miniconda [from here](https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-x86_64.pkg).
+2. Install Miniconda by double-clicking the downloaded file. Follow the appearing installation instructions and remember in which folder you install Miniconda. (Optional:) If you already use Anaconda or Python on your computer, deactivate all installation options which put Miniconda to PATH to avoid possible problems.
+3. Using Finder, go to the folder where you installed Miniconda. Then, open the appearing sub-folder "condabin".
+4. Download the CNApy installation assistant script [from here](https://github.com/cnapy-org/CNApy/releases/download/v1.1.6/cnapy-installation-script.sh) into the mentioned "condabin" folder.
+5. In the file manager, double-click on the newly downloaded installation assistant script which is called "cnapy-installation-script.sh". If the script does not run, right-click on the file, open its settings and select the option to make it executable (alternative: run 'chmod u+x ./cnapy-installation-script.sh' in your terminal). Wait until CNApy is downloaded and installed.
+6. Open the terminal in the mentioned "condabin" folder. You can now run CNApy by executing the following two terminal instructions:
+
+```sh
+./conda activate cnapy-1.1.6
+cnapy
+```
+
 ## Install CNApy as conda package
 
-1. We use conda as package manager to install CNApy, so that, if not already done yet, you have to install either the full-fledged [Anaconda](https://www.anaconda.com/) or the smaller [miniconda](https://docs.conda.io/en/latest/miniconda.html) conda installern on your system.
-
-2. Add the additional channels used by CNApy to conda:
+1. Create a conda environment with all dependencies
 
     ```sh
-    conda config --add channels IBMDecisionOptimization
-    conda config --add channels Gurobi
+    conda create -n cnapy-1.1.6 -c Gurobi -c IBMDecisionOptimization -c conda-forge -c cnapy cnapy=1.1.6 --yes
     ```
 
-3. Create a conda environment with all dependencies
-
-    ```sh
-    conda create -n cnapy-1.1.6 -c conda-forge -c cnapy cnapy=1.1.6
-    ```
-
-4. Activate the cnapy conda environment
+2. Activate the cnapy conda environment
 
     ```sh
     conda activate cnapy-1.1.6
     ```
 
-5. Run CNApy within you activated conda environment
+3. Run CNApy within you activated conda environment
 
     ```sh
     cnapy
@@ -87,14 +123,14 @@ Everyone is welcome to contribute to CNApy's development. [See our contribution 
 
 Furthermore, you can also perform the following optional steps:
 
-6. (optional and only recommended if you have already installed CNApy by using conda) If you already have a cnapy environment, e.g., cnapy-1.X.X, you can delete it with the command
+4. (optional and only recommended if you have already installed CNApy by using conda) If you already have a cnapy environment, e.g., cnapy-1.X.X, you can delete it with the command
 
     ```sh
     # Here, the Xs stand for the last CNApy version you've installed by using conda
     conda env remove -n cnapy-1.X.X
     ```
 
-7. (optional, but recommended if you also use other Python distributions or Anaconda environments) In order to solve potential package version problems, set a systems variable called "PYTHONNOUSERSITE" to the value "True".
+5. (optional, but recommended if you also use other Python distributions or Anaconda environments) In order to solve potential package version problems, set a systems variable called "PYTHONNOUSERSITE" to the value "True".
 
    Under Linux systems, you can do this with the following command:
 

--- a/cnapy/appdata.py
+++ b/cnapy/appdata.py
@@ -25,7 +25,7 @@ class ModelItemType(IntEnum):
     Metabolite = 0
     Reaction = 1
     Gene = 2
- 
+
 class AppData:
     ''' The application data '''
 
@@ -41,6 +41,7 @@ class AppData:
         self.scen_color_warn = QColor(255, 200, 0)
         self.scen_color_bad = Qt.red
 
+        self.font_size = 9
         self.box_width = 80
         self.box_height = 40
         self.comp_color = QColor(0, 170, 255)
@@ -150,6 +151,7 @@ class AppData:
         parser.set('cnapy-config', 'spec1_color', str(self.special_color_1.rgb()))
         parser.set('cnapy-config', 'spec2_color', str(self.special_color_2.rgb()))
         parser.set('cnapy-config', 'default_color', str(self.default_color.rgb()))
+        parser.set('cnapy-config', 'font_size', str(self.font_size))
         parser.set('cnapy-config', 'box_width', str(self.box_width))
         parser.set('cnapy-config', 'rounding', str(self.rounding))
         parser.set('cnapy-config', 'abs_tol', str(self.abs_tol))

--- a/cnapy/application.py
+++ b/cnapy/application.py
@@ -170,7 +170,7 @@ class Application:
             try:
                 font_size = config_parser.get(
                     'cnapy-config', 'font_size')
-                self.appdata.font_size = int(font_size)
+                self.appdata.font_size = float(font_size)
             except (KeyError, NoOptionError):
                 print("Could not find font_size in cnapy-config.txt")
             try:

--- a/cnapy/application.py
+++ b/cnapy/application.py
@@ -68,6 +68,10 @@ class Application:
         self.qapp = QApplication(sys.argv)
         self.appdata = AppData()
         self.qapp.setStyle("fusion")
+        config_file_version = self.read_config()
+        font = self.qapp.font()
+        font.setPointSize(self.appdata.font_size)
+        self.qapp.setFont(font)
         self.window = MainWindow(self.appdata)
         self.appdata.window = self.window
         self.window.recreate_maps()
@@ -75,8 +79,6 @@ class Application:
         self.window.save_project_action.setEnabled(False)
         self.window.show()
 
-        config_file_version = self.read_config()
-        self.qapp.setStyleSheet("*{font-size: "+str(self.appdata.font_size)+"pt;}")
         # First start-up behaviour (it can also happen whenever the cnapy-config.txt is deleted)
         if config_file_version == "unknown":
             self.first_start_up_message()

--- a/cnapy/application.py
+++ b/cnapy/application.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import cobra
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QColor
+from qtpy.QtGui import QColor, QFont
 from qtpy.QtWidgets import QApplication
 from qtpy.QtWidgets import QMessageBox
 
@@ -76,6 +76,7 @@ class Application:
         self.window.show()
 
         config_file_version = self.read_config()
+        self.qapp.setStyleSheet("*{font-size: "+str(self.appdata.font_size)+"pt;}")
         # First start-up behaviour (it can also happen whenever the cnapy-config.txt is deleted)
         if config_file_version == "unknown":
             self.first_start_up_message()
@@ -98,7 +99,9 @@ class Application:
         msgBox.setText(
             "Welcome to CNApy! In the next step, you can choose to download CNApy's "
             "metabolic network example projects.\n"
-            "You can also do this later under 'Project->Download CNApy example projects...'."
+            "You can also do this later under 'Project->Download CNApy example projects...'.\n"
+            "Also, should CNApy's font size be too small or too large, you can change\n"
+            "it under 'Config->Configure CNApy...'."
         )
         msgBox.setIcon(QMessageBox.Information)
         msgBox.exec()
@@ -162,6 +165,12 @@ class Application:
                 self.appdata.default_color = QColor.fromRgb(int(color))
             except (KeyError, NoOptionError):
                 print("Could not find default_color in cnapy-config.txt")
+            try:
+                font_size = config_parser.get(
+                    'cnapy-config', 'font_size')
+                self.appdata.font_size = int(font_size)
+            except (KeyError, NoOptionError):
+                print("Could not find font_size in cnapy-config.txt")
             try:
                 box_width = config_parser.get(
                     'cnapy-config', 'box_width')

--- a/cnapy/gui_elements/config_dialog.py
+++ b/cnapy/gui_elements/config_dialog.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from qtpy.QtGui import QDoubleValidator, QIntValidator, QPalette
 from qtpy.QtWidgets import (QColorDialog, QDialog, QFileDialog,
-                            QHBoxLayout, QLabel, QLineEdit, QPushButton,
+                            QHBoxLayout, QLabel, QLineEdit, QMessageBox, QPushButton,
                             QVBoxLayout, QCheckBox)
 from cnapy.appdata import AppData
 
@@ -12,12 +12,23 @@ from cnapy.appdata import AppData
 class ConfigDialog(QDialog):
     """A dialog to set values in cnapy-config.txt"""
 
-    def __init__(self, appdata: AppData, first_start: bool):
+    def __init__(self, main_window, first_start: bool):
         QDialog.__init__(self)
         self.setWindowTitle("Configure CNApy")
-        self.appdata = appdata
+        self.main_window = main_window
+        self.appdata: AppData = main_window.appdata
 
         self.layout = QVBoxLayout()
+
+        fs = QHBoxLayout()
+        label = QLabel("Font size:")
+        fs.addWidget(label)
+        self.font_size = QLineEdit()
+        self.font_size.setFixedWidth(100)
+        self.font_size.setText(str(self.appdata.font_size))
+        fs.addWidget(self.font_size)
+        self.layout.addItem(fs)
+
         bw = QHBoxLayout()
         label = QLabel("Box width:")
         bw.addWidget(label)
@@ -219,6 +230,17 @@ class ConfigDialog(QDialog):
             self.default_color_btn.setPalette(palette)
 
     def apply(self):
+        new_fontsize = int(self.font_size.text())
+        if new_fontsize != self.appdata.font_size:
+            self.appdata.font_size = new_fontsize
+            self.main_window.setStyleSheet("*{font-size: "+str(new_fontsize)+"pt;}")
+            QMessageBox.information(
+                self,
+                "Restart for full font size change effect",
+                "Please restart CNApy. This will also apply your font size change "
+                "on all of CNApy's subwindows."
+            )
+
         self.appdata.box_width = int(self.box_width.text())
 
         self.appdata.work_directory = self.work_directory.text()

--- a/cnapy/gui_elements/config_dialog.py
+++ b/cnapy/gui_elements/config_dialog.py
@@ -230,7 +230,7 @@ class ConfigDialog(QDialog):
             self.default_color_btn.setPalette(palette)
 
     def apply(self):
-        new_fontsize = int(self.font_size.text())
+        new_fontsize = float(self.font_size.text())
         if new_fontsize != self.appdata.font_size:
             self.appdata.font_size = new_fontsize
             self.main_window.setStyleSheet("*{font-size: "+str(new_fontsize)+"pt;}")

--- a/cnapy/gui_elements/download_dialog.py
+++ b/cnapy/gui_elements/download_dialog.py
@@ -25,7 +25,8 @@ class DownloadDialog(QDialog):
         label = QLabel(
             "Should CNApy download metabolic network example projects to your CNApy working directory?\n"
             "This requires an active internet connection.\n"
-            "If a working directory error occurs, you can solve by setting a working directory under 'Config->Configure CNApy'."
+            "If a working directory error occurs, you can solve by setting a working directory under 'Config->Configure CNApy'.\n"
+            "In this configuration dialog, you can also change CNApy's font size."
         )
         label_line.addWidget(label)
         self.layout.addItem(label_line)

--- a/cnapy/gui_elements/flux_feasibility_dialog.py
+++ b/cnapy/gui_elements/flux_feasibility_dialog.py
@@ -2,7 +2,7 @@ from math import copysign
 from qtpy.QtCore import Qt, Slot, QSignalBlocker
 from qtpy.QtWidgets import (QDialog, QGroupBox, QHBoxLayout, QTableWidget, QCheckBox, QMainWindow,
                             QLabel, QLineEdit, QMessageBox, QPushButton, QAbstractItemView, QAction,
-                            QRadioButton, QVBoxLayout, QTableWidgetItem, QButtonGroup, 
+                            QRadioButton, QVBoxLayout, QTableWidgetItem, QButtonGroup,
                             QStyledItemDelegate, QTableWidgetSelectionRange)
 from qtpy.QtGui import QGuiApplication
 
@@ -153,7 +153,7 @@ class FluxFeasibilityDialog(QDialog):
         hbox.addWidget(QLabel("Maximal change in ATP amount: "))
         self.gam_max_change = QLineEdit("20")
         hbox.addWidget(self.gam_max_change)
-        vbox_gam.addLayout(hbox)        
+        vbox_gam.addLayout(hbox)
         hbox.addWidget(QLabel("Weight for ATP change: "))
         self.gam_weight = QLineEdit("0.1")
         hbox.addWidget(self.gam_weight)
@@ -234,7 +234,7 @@ class FluxFeasibilityDialog(QDialog):
                         "The maximal relative coefficient change must be a number between 0 and 100.")
 
                     return
-            
+
             if self.adjust_gam.isChecked():
                 gam_mets = self.gam_mets.text().split()
                 try:
@@ -281,7 +281,7 @@ class FluxFeasibilityDialog(QDialog):
                 gam_mets_param = (gam_mets, 0.0, 0.0, 0.0)
         else:
             bm_reac_id = ""
-        
+
         # if the last scenario change comes from the previous computation undo it
         if self.modified_scenario is self.appdata.scenario_past[-1]:
             self.main_window.undo_scenario_edit()

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -698,7 +698,7 @@ class MainWindow(QMainWindow):
 
     @Slot()
     def show_config_dialog(self, first_start=False):
-        dialog = ConfigDialog(self.appdata, first_start)
+        dialog = ConfigDialog(self, first_start)
         if not first_start:
             dialog.exec_()
 


### PR DESCRIPTION
In the light of our latest problem with the CNApy installer, I propose a new installation protocol (which successfully resolved the latest installation issue) where the installation of Miniconda and cnapy is only semi-automated. Also, this method works for all common operating systems. Feel free to share your thoughts about this installation protocol proposal :-)

The associated installation assistant script can be found [here](https://github.com/cnapy-org/CNApy/files/10859991/assistant_scripts.zip). The would be added to all future releases as assets.