### PR TITLE
Multiple MCS dialog improvements

### DIFF
--- a/cnapy/gui_elements/mcs_dialog.py
+++ b/cnapy/gui_elements/mcs_dialog.py
@@ -4,7 +4,7 @@ import io
 import scipy
 
 from qtpy.QtCore import Qt, Slot
-from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox,
+from qtpy.QtWidgets import (QButtonGroup, QCheckBox, QComboBox, QCompleter,
                             QDialog, QGroupBox, QHBoxLayout, QHeaderView,
                             QLabel, QLineEdit, QMessageBox, QPushButton,
                             QRadioButton, QTableWidget, QVBoxLayout)
@@ -196,6 +196,17 @@ class MCSDialog(QDialog):
         # Connecting the signal
         self.cancel.clicked.connect(self.reject)
         self.compute_mcs.clicked.connect(self.compute)
+
+        self.central_widget.broadcastReactionID.connect(self.receive_input)
+
+    @Slot(str)
+    def receive_input(self, text):
+        if self.isVisible():
+            completer_mode = self.active_receiver.completer.completionMode()
+            # temporarily disable completer popup
+            self.active_receiver.completer.setCompletionMode(QCompleter.CompletionMode.InlineCompletion)
+            self.active_receiver.insert(text+' ')
+            self.active_receiver.completer.setCompletionMode(completer_mode)
 
     @Slot()
     def set_optlang_solver_text(self):

--- a/cnapy/gui_elements/mcs_dialog.py
+++ b/cnapy/gui_elements/mcs_dialog.py
@@ -318,7 +318,6 @@ class MCSDialog(QDialog):
             for i in range(0, rows):
                 p1 = self.target_list.cellWidget(i, 0).text()
                 p2 = self.target_list.cellWidget(i, 1).text()
-                p2 = p2.replace(" - ", " + -")  # Clunky fix to allow "-" in equations
                 if len(p1) > 0 and len(p2) > 0:
                     if self.target_list.cellWidget(i, 2).currentText() == '≤':
                         p3 = "<="
@@ -351,9 +350,7 @@ class MCSDialog(QDialog):
             desired_dict = dict()
             for i in range(0, rows):
                 p1 = self.desired_list.cellWidget(i, 0).text()
-                p1 = p1.replace(" - ", " + -")
                 p2 = self.desired_list.cellWidget(i, 1).text()
-                p2 = p2.replace(" - ", " + -")  # Clunky fix to allow "-" in equations
                 if len(p1) > 0 and len(p2) > 0:
                     if self.desired_list.cellWidget(i, 2).currentText() == '≤':
                         p3 = "<="

--- a/cnapy/utils.py
+++ b/cnapy/utils.py
@@ -127,9 +127,8 @@ class SignalThrottler(QObject):
 class QComplReceivLineEdit(QLineEdit):
     '''# does new completion after SPACE'''
 
-    def __init__(self, sd_dialog, wordlist, check=True, is_constr=False, reject_empty_string=True):
-        super().__init__("")
-        self.sd_dialog = sd_dialog
+    def __init__(self, parent, wordlist, check=True, is_constr=False, reject_empty_string=True):
+        super().__init__("", parent)
         self.completer: QCompleter = QCompleter()
         self.completer.setCaseSensitivity(Qt.CaseInsensitive)
         if len(wordlist) > 0:
@@ -174,7 +173,7 @@ class QComplReceivLineEdit(QLineEdit):
 
     def focusInEvent(self, event):
         super().focusInEvent(event)
-        self.sd_dialog.active_receiver = self
+        self.parent().active_receiver = self
 
     def focusOutEvent(self, event):
         super().focusOutEvent(event)

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - requests=2.28
   - psutil=5.9
   - efmtool_link=0.0.4
-  - optlang_enumerator>=0.0.8
+  - optlang_enumerator>=0.0.9
   - straindesign>=1.9
   - nest-asyncio
   - gurobi

--- a/recipes/linux/meta.yaml
+++ b/recipes/linux/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - requests=2.28
     - psutil=5.9
     - efmtool_link=0.0.4
-    - optlang_enumerator>=0.0.8
+    - optlang_enumerator>=0.0.9
     - straindesign>=1.9
     - gurobi
     - cplex

--- a/recipes/noarch/meta.yaml
+++ b/recipes/noarch/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - requests=2.28
     - psutil=5.9
     - efmtool_link=0.0.4
-    - optlang_enumerator>=0.0.8
+    - optlang_enumerator>=0.0.9
     - straindesign>=1.9
     - nest-asyncio
     - gurobi

--- a/recipes/win/meta.yaml
+++ b/recipes/win/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - requests=2.28
     - psutil=5.9
     - efmtool_link=0.0.4
-    - optlang_enumerator>=0.0.8
+    - optlang_enumerator>=0.0.9
     - straindesign>=1.9
     - nest-asyncio
     - gurobi


### PR DESCRIPTION
This PR aims to fix the following MCS dialog issues:
* The rusty left-hand-side parse is now removed, so that the issues with parsing seceral mathematical operators do not occur anymore.
* As a replacement, I expanded the list comprehension of MCSDialog's parsing the desired and target regions such that, if an error occurs, a pop-up window appears telling the user in which target or desired region the error occurs. Also, TypeErrors are now caught (this was missing up to now but could happen, if, e.g., a user types in values such as "1.2d").
* Furthermore, full reaction name complemetions (not only for the first reaction) as in the StrainDesign dialog was added through the usage of QComplReceivLineEdit from cnapy.utils. Unfortunately, the checker which automatically colors a line red if the equation is wrong doesn't work here as this checker also demands a ">=" or "<=" and cannot work with "/".
* Finally, as a clunky fix to allow the usage of "-", " - " occurreces in the left hand sides are replaces with " + -", which somehow works with the MCS parser here.

Any ideas, especially regarding a higher level of congruence with StrainDesign, are very welcome :-)