### PR TITLE
Change cplex package to ARM-MacOS-compatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,24 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
 ]
-dependencies = ["appdirs>=1.4", "matplotlib>=3.6", "requests>=2.28",
-                "cobra>=0.29", "efmtool_link>=0.0.8", "optlang_enumerator>=0.0.12", "straindesign>=1.12",
-                "qtpy>=2.3", "pyqtwebengine>=5.15", "qtconsole==5.4",
-                "gurobipy==11.*", "cplex==22.1.1.2", "numpy==1.23", "scipy==1.12", "openpyxl", "jpype1==1.5.0"]
+dependencies = [
+    "appdirs>=1.4",
+    "matplotlib>=3.6",
+    "requests>=2.28",
+    "cobra>=0.29",
+    "efmtool_link>=0.0.8",
+    "optlang_enumerator>=0.0.12",
+    "straindesign>=1.12",
+    "qtpy>=2.3",
+    "pyqtwebengine>=5.15",
+    "qtconsole==5.4",
+    "gurobipy==11.*",
+    "cplex==22.1.1.2", # We use this specific version as it's the only one with support for ARM Macs
+    "numpy==1.23",
+    "scipy==1.12",
+    "openpyxl",
+    "jpype1==1.5.0"
+]
 
 [project.scripts]
 cnapy = "cnapy.__main__:main_cnapy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = ["appdirs>=1.4", "matplotlib>=3.6", "requests>=2.28",
                 "cobra>=0.29", "efmtool_link>=0.0.8", "optlang_enumerator>=0.0.12", "straindesign>=1.12",
                 "qtpy>=2.3", "pyqtwebengine>=5.15", "qtconsole==5.4",
-                "gurobipy==11.*", "cplex>=22.1", "numpy==1.23", "scipy==1.12", "openpyxl", "jpype1==1.5.0"]
+                "gurobipy==11.*", "cplex==22.1.1.2", "numpy==1.23", "scipy==1.12", "openpyxl", "jpype1==1.5.0"]
 
 [project.scripts]
 cnapy = "cnapy.__main__:main_cnapy"


### PR DESCRIPTION
For some reason, only ```cplex``` in version 22.1.1.2 supports ARM MacOS (I tested it successfully together with the ARM version of CPLEX); The newer version  22.1.2.0 does not support it anymore. As both versions are compatible with the latest CPLEX, I fixed the version for our ARM MacOS users.