### PR TITLE
Small setuptools dependency fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,6 @@ venv.bak/
 # mypy
 .mypy_cache/
 cnapy-config.txt
+
+# uv files
+uv.lock

--- a/README.md
+++ b/README.md
@@ -82,10 +82,12 @@ Programatically, we recommend to use uv [[GitHub]](https://github.com/astral-sh/
 ### uv usage
 You can use uv for CNApy as follows:
 
-1. Make sure that you have installed uv (*Note*: uv can be installed under any Python version as uv will manage the needed Python version later):
+1. Make sure that you have installed uv, e.g. through pip, pipx or another package manger (```apt```, ```brew```, ```nix``` ...) of your choice:
 
 ```sh
-pip install uv
+# E.g., you can install uv through
+pip install uv # or
+pipx install uv
 ```
 
 2. Checkout the latest cnapy development version using git
@@ -101,7 +103,7 @@ cd CNApy
 uv run cnapy.py
 ```
 
-uv will automatically install the correct Python version (by reading ./.python-version) and CNApy dependencies (by reading ./pyproject.toml). If you get a Java/JDK/JVM/jpype error when running CNApy, consider installing OpenJDK [[Site]](https://openjdk.org/install/) on your system to fix this problem.
+uv will automatically install the correct Python version and CNApy dependencies (all done by reading CNApy's pyproject.toml file). If you get a Java/JDK/JVM/jpype error when running CNApy, consider installing OpenJDK [[Site]](https://openjdk.org/install/) on your system to fix this problem.
 
 ## How to cite CNApy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "numpy==1.23",
     "scipy==1.12",
     "openpyxl",
-    "jpype1==1.5.0"
+    "jpype1==1.5.0",
+    "setuptools",
 ]
 
 [project.scripts]


### PR DESCRIPTION
At least on my Macintosh, CNApy won't start with uv as ```package_resources```is needed and only included in ```setuptools```. Hence, I added it to the dependencies and also refurbished the uv explanation a little bit.