### PR TITLE
Update python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
       with:
-        user: axelk1
+        user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
There was a change in the PyPI policy not to connect tokens with usernames, hence, it's now just __token__