### PR TITLE
Add ability to load project and scenario as command-line arguments

### DIFF
--- a/cnapy.py
+++ b/cnapy.py
@@ -14,4 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from cnapy.__main__ import main_cnapy
-main_cnapy()
+from sys import argv
+
+print(argv)
+main_cnapy(
+    project_path=None if len(argv) < 2 else argv[1],
+    scenario_path=None if len(argv) < 3 else argv[2],
+)

--- a/cnapy/__main__.py
+++ b/cnapy/__main__.py
@@ -30,8 +30,14 @@ except (JVMNotFoundException, JVMNotSupportedException):
 
 from cnapy.application import Application
 
-def main_cnapy():
-    Application()
+def main_cnapy(
+    project_path: None | str,
+    scenario_path: None | str,
+):
+    Application(
+        project_path=project_path,
+        scenario_path=scenario_path,
+    )
 
 if __name__ == "__main__":
     main_cnapy()

--- a/cnapy/application.py
+++ b/cnapy/application.py
@@ -64,7 +64,11 @@ sys.excepthook = excepthook
 class Application:
     '''The Application class'''
 
-    def __init__(self):
+    def __init__(
+        self,
+        project_path: None | str,
+        scenario_path: None | str,
+    ):
         QLocale.setDefault(QLocale(QLocale.English)) # to set . as decimal point
         self.qapp = QApplication(sys.argv)
         self.appdata = AppData()
@@ -73,7 +77,7 @@ class Application:
         font = self.qapp.font()
         font.setPointSizeF(self.appdata.font_size)
         self.qapp.setFont(font)
-        self.window = MainWindow(self.appdata)
+        self.window = MainWindow(self.appdata, project_path, scenario_path)
         self.appdata.window = self.window
         self.appdata.unsavedScenarioChanges.connect(self.window.update_scenario_file_name)
         self.window.recreate_maps()
@@ -94,7 +98,8 @@ class Application:
 
         # Execute application
         self.qapp.aboutToQuit.connect(
-            self.window.centralWidget().shutdown_kernel)
+            self.window.centralWidget().shutdown_kernel
+        )
         sys.exit(self.qapp.exec_())
 
     def first_start_up_message(self):

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -53,7 +53,7 @@ SBML_suffixes = "*.xml *.sbml *.xml.gz *.sbml.gz *.xml.zip *.sbml.zip"
 class MainWindow(QMainWindow):
     """The cnapy main window"""
 
-    def __init__(self, appdata: AppData):
+    def __init__(self, appdata: AppData, project_path: str | None, scenario_path: str | None):
         QMainWindow.__init__(self)
         self.setWindowTitle("cnapy")
         self.appdata = appdata
@@ -589,6 +589,11 @@ class MainWindow(QMainWindow):
 
         self.update_scenario_file_name()
         self.centralWidget().map_tabs.currentChanged.connect(self.on_tab_change)
+
+        if project_path is not None:
+            self.open_project(project_path)
+        if scenario_path is not None:
+            self.load_scenario_file(scenario_path)
 
     def closeEvent(self, event):
         if self.checked_unsaved():


### PR DESCRIPTION
Now you can, via command-line arguments (first is the project file path, second the scenario), startup CNApy directly with a model and a scenario