### PR TITLE
Add optional QML-based map view (QQuickWidget) with feature flag and migration notes

### DIFF
--- a/cnapy/gui_elements/central_widget.py
+++ b/cnapy/gui_elements/central_widget.py
@@ -1,5 +1,8 @@
 """The central widget"""
 
+import importlib
+import os
+
 import numpy
 from enum import IntEnum
 import cobra
@@ -12,6 +15,26 @@ from qtpy.QtWidgets import (QCheckBox, QDialog, QHBoxLayout, QLabel, QLineEdit, 
 
 from cnapy.appdata import AppData, CnaMap, ModelItemType, parse_scenario
 from cnapy.gui_elements.map_view import MapView
+
+
+def create_cnapy_map_view(appdata, central_widget, name: str):
+    """Create the standard CNApy map view, optionally using Qt Quick.
+
+    Set CNAPY_QML_MAP_VIEW=1 to opt into the experimental hardware-
+    accelerated QML implementation while keeping the existing QGraphicsView
+    path as the default.
+    """
+    if os.environ.get("CNAPY_QML_MAP_VIEW") == "1":
+        qml_map_view = importlib.import_module("cnapy.gui_elements.qml_map_view")
+        return qml_map_view.QmlMapView(appdata, central_widget, name)
+    return MapView(appdata, central_widget, name)
+
+
+def is_cnapy_map_view(widget) -> bool:
+    """Return whether *widget* is a CNApy map, regardless of rendering backend."""
+    return isinstance(widget, MapView) or widget.__class__.__name__ == "QmlMapView"
+
+
 from cnapy.gui_elements.escher_map_view import EscherMapView
 from cnapy.gui_elements.metabolite_list import MetaboliteList
 from cnapy.gui_elements.gene_list import GeneList
@@ -170,8 +193,9 @@ class CentralWidget(QWidget):
         self.update()
 
     def fit_mapview(self):
-        if isinstance(self.map_tabs.currentWidget(), MapView):
-            self.map_tabs.currentWidget().fit()
+        current = self.map_tabs.currentWidget()
+        if hasattr(current, "fit"):
+            current.fit()
 
     def show_bottom_of_console(self):
         (_, r) = self.splitter2.getRange(1)
@@ -333,7 +357,7 @@ class CentralWidget(QWidget):
             # self.appdata.qapp.processEvents() # does not help
             idx = self.map_tabs.addTab(mmap, m["name"])
         else:
-            mmap = MapView(self.appdata, self, name)
+            mmap = create_cnapy_map_view(self.appdata, self, name)
             self.connect_map_view_signals(mmap)
             idx = self.map_tabs.addTab(mmap, m["name"])
             self.update_maps() # only update mmap?
@@ -562,7 +586,7 @@ class CentralWidget(QWidget):
                                 update_cnapy_maps:bool=True, update_escher_maps:bool=False):
         for idx in range(0, self.map_tabs.count()):
             m = self.map_tabs.widget(idx)
-            if update_cnapy_maps and isinstance(m, MapView):
+            if update_cnapy_maps and is_cnapy_map_view(m):
                 m.update_reaction(old_reaction_id, new_reaction_id)
             elif update_escher_maps and isinstance(m, EscherMapView):
                 if old_reaction_id != new_reaction_id:
@@ -573,7 +597,7 @@ class CentralWidget(QWidget):
     def delete_reaction_on_maps(self, reation_id: str):
         for idx in range(0, self.map_tabs.count()):
             m = self.map_tabs.widget(idx)
-            if isinstance(m, MapView):
+            if is_cnapy_map_view(m):
                 m.delete_box(reation_id)
             else:
                 m.delete_reaction(reation_id)

--- a/cnapy/gui_elements/main_window.py
+++ b/cnapy/gui_elements/main_window.py
@@ -28,14 +28,15 @@ from qtpy.QtWebEngineWidgets import QWebEngineView
 
 from cnapy.appdata import AppData, CnaMap
 from cnapy.gui_elements.about_dialog import AboutDialog
-from cnapy.gui_elements.central_widget import CentralWidget, ModelTabIndex
+from cnapy.gui_elements.central_widget import (CentralWidget, ModelTabIndex,
+                                        create_cnapy_map_view,
+                                        is_cnapy_map_view)
 from cnapy.gui_elements.clipboard_calculator import ClipboardCalculator
 from cnapy.gui_elements.config_dialog import ConfigDialog
 from cnapy.gui_elements.download_dialog import DownloadDialog
 from cnapy.gui_elements.config_cobrapy_dialog import ConfigCobrapyDialog
 from cnapy.gui_elements.efmtool_dialog import EFMtoolDialog
 from cnapy.gui_elements.flux_feasibility_dialog import FluxFeasibilityDialog
-from cnapy.gui_elements.map_view import MapView
 from cnapy.gui_elements.escher_map_view import EscherMapView
 from cnapy.gui_elements.mcs_dialog import MCSDialog
 from cnapy.gui_elements.strain_design_dialog import SDDialog, SDComputationViewer, SDViewer, SDComputationThread
@@ -1527,7 +1528,7 @@ class MainWindow(QMainWindow):
         self.delete_maps()
         for name, mmap in self.appdata.project.maps.items():
             if mmap.get("view", "cnapy") == "cnapy":
-                mmap = MapView(self.appdata, self.centralWidget(), name)
+                mmap = create_cnapy_map_view(self.appdata, self.centralWidget(), name)
                 mmap.show()
                 self.centralWidget().connect_map_view_signals(mmap)
             elif mmap["view"] == "escher":
@@ -1581,7 +1582,7 @@ class MainWindow(QMainWindow):
             self.dec_bg_size_action.setEnabled(True)
             self.save_box_positions_action.setEnabled(True)
             self.centralWidget().update_map(idx)
-            if isinstance(self.centralWidget().map_tabs.widget(idx), MapView):
+            if is_cnapy_map_view(self.centralWidget().map_tabs.widget(idx)):
                 self.escher_map_actions.setVisible(False)
                 self.cnapy_map_actions.setVisible(True)
                 self.colorings.setEnabled(True)

--- a/cnapy/gui_elements/qml/MapView.qml
+++ b/cnapy/gui_elements/qml/MapView.qml
@@ -1,0 +1,124 @@
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: mapRoot
+    objectName: "qmlMapRoot"
+    focus: true
+
+    property var filterTerms: []
+
+    function setFilterTerms(terms) {
+        filterTerms = terms
+    }
+
+    function acceptsReaction(reactionId, reactionName) {
+        if (filterTerms.length === 0) {
+            return true
+        }
+        const id = reactionId.toLowerCase()
+        const name = reactionName.toLowerCase()
+        for (let i = 0; i < filterTerms.length; ++i) {
+            if (id.indexOf(filterTerms[i]) !== -1 || name.indexOf(filterTerms[i]) !== -1) {
+                return true
+            }
+        }
+        return false
+    }
+
+    function mapToMapLayer(x, y) {
+        const point = flick.mapToItem(mapLayer, x, y)
+        return Qt.point(point.x / mapLayer.scale, point.y / mapLayer.scale)
+    }
+
+    function centerOnPoint(x, y) {
+        flick.contentX = Math.max(0, x * mapLayer.scale - flick.width / 2)
+        flick.contentY = Math.max(0, y * mapLayer.scale - flick.height / 2)
+    }
+
+    function fitToView() {
+        if (mapLayer.implicitWidth <= 0 || mapLayer.implicitHeight <= 0) {
+            return
+        }
+        const widthScale = flick.width / mapLayer.implicitWidth
+        const heightScale = flick.height / mapLayer.implicitHeight
+        const target = Math.min(widthScale, heightScale)
+        // Keep project zoom integral, matching the existing QGraphicsView semantics.
+        let steps = 0
+        let factor = 1.0
+        while (factor * 1.1 < target) {
+            factor *= 1.1
+            steps += 1
+        }
+        while (factor > target) {
+            factor /= 1.1
+            steps -= 1
+        }
+        mapController.zoomSteps(steps - Math.round(Math.log(mapController.zoomFactor) / Math.log(1.1)))
+        flick.contentX = 0
+        flick.contentY = 0
+    }
+
+    Flickable {
+        id: flick
+        anchors.fill: parent
+        clip: true
+        contentWidth: Math.max(width, mapLayer.implicitWidth * mapLayer.scale)
+        contentHeight: Math.max(height, mapLayer.implicitHeight * mapLayer.scale)
+        boundsBehavior: Flickable.StopAtBounds
+        interactive: true
+        Component.onCompleted: {
+            contentX = mapController.contentX
+            contentY = mapController.contentY
+        }
+        onContentXChanged: mapController.setViewportPosition(contentX, contentY)
+        onContentYChanged: mapController.setViewportPosition(contentX, contentY)
+
+        Item {
+            id: mapLayer
+            property real implicitWidth: Math.max(background.implicitWidth * mapController.backgroundScale, 2000)
+            property real implicitHeight: Math.max(background.implicitHeight * mapController.backgroundScale, 1200)
+            width: implicitWidth
+            height: implicitHeight
+            scale: mapController.zoomFactor
+            transformOrigin: Item.TopLeft
+
+            Image {
+                id: background
+                source: mapController.backgroundUrl
+                asynchronous: true
+                cache: true
+                width: implicitWidth * mapController.backgroundScale
+                height: implicitHeight * mapController.backgroundScale
+                fillMode: Image.PreserveAspectFit
+            }
+
+            Repeater {
+                model: mapController.reactionBoxes
+                delegate: ReactionBoxDelegate {
+                    x: boxX
+                    y: boxY
+                    reactionId: model.reactionId
+                    reactionName: model.reactionName
+                    valueText: model.valueText
+                    fillColor: model.fillColor
+                    foregroundColor: model.foregroundColor
+                    selected: model.selected
+                    tooltipText: model.tooltipText
+                    onMoved: (newX, newY) => mapController.setBoxPosition(reactionId, newX, newY)
+                    onValueEdited: value => mapController.setReactionValue(reactionId, value)
+                }
+            }
+        }
+    }
+
+    WheelHandler {
+        acceptedModifiers: Qt.NoModifier
+        onWheel: event => mapController.zoomSteps(event.angleDelta.y > 0 ? 1 : -1)
+    }
+
+    WheelHandler {
+        acceptedModifiers: Qt.ControlModifier
+        onWheel: event => mapController.scaleBoxesBy(event.angleDelta.y > 0 ? 1.1 : 1 / 1.1)
+    }
+}

--- a/cnapy/gui_elements/qml/ReactionBoxDelegate.qml
+++ b/cnapy/gui_elements/qml/ReactionBoxDelegate.qml
@@ -1,0 +1,100 @@
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: root
+
+    property string reactionId: ""
+    property string reactionName: ""
+    property string valueText: ""
+    property string fillColor: "#66ffffff"
+    property string foregroundColor: "#ff000000"
+    property string tooltipText: ""
+    property bool selected: false
+    signal moved(real newX, real newY)
+    signal valueEdited(string value)
+
+    width: mapController.boxWidth * mapController.boxScale
+    height: mapController.boxHeight * mapController.boxScale
+    scale: mapController.boxScale
+    transformOrigin: Item.TopLeft
+    visible: mapRoot.acceptsReaction(reactionId, reactionName)
+
+    Rectangle {
+        anchors.fill: parent
+        color: root.fillColor
+        border.color: root.selected ? "#6464c8" : "#666666"
+        border.width: root.selected ? 4 : 1
+        radius: 2
+    }
+
+    TextInput {
+        id: valueInput
+        anchors.fill: parent
+        anchors.margins: 2
+        color: root.foregroundColor
+        text: root.valueText
+        selectByMouse: true
+        verticalAlignment: TextInput.AlignVCenter
+        font.pointSize: 14
+        onEditingFinished: root.valueEdited(text)
+        onAccepted: focus = false
+    }
+
+    Rectangle {
+        x: -15
+        y: -15
+        width: 20
+        height: 20
+        radius: 10
+        color: "transparent"
+        border.color: "#a9a9a9"
+        border.width: 1
+    }
+
+    Rectangle {
+        x: -10
+        y: -6
+        width: 10
+        height: 2
+        color: "#a9a9a9"
+    }
+
+    Rectangle {
+        x: -6
+        y: -10
+        width: 2
+        height: 10
+        color: "#a9a9a9"
+    }
+
+    MouseArea {
+        id: mouseArea
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        hoverEnabled: true
+        drag.target: root
+        onPressed: mouse => {
+            if (mouse.button === Qt.LeftButton) {
+                mapController.setSelected(root.reactionId, !root.selected || !(mouse.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)), !(mouse.modifiers & (Qt.ControlModifier | Qt.ShiftModifier)))
+            } else if (mouse.button === Qt.RightButton) {
+                contextMenu.popup()
+            }
+        }
+        onDoubleClicked: mapController.switchToReaction(root.reactionId)
+        onReleased: root.moved(root.x, root.y)
+    }
+
+    ToolTip.visible: mouseArea.containsMouse
+    ToolTip.text: root.tooltipText
+
+    Menu {
+        id: contextMenu
+        MenuItem { text: "maximize flux for this reaction"; onTriggered: mapController.maximize(root.reactionId) }
+        MenuItem { text: "minimize flux for this reaction"; onTriggered: mapController.minimize(root.reactionId) }
+        MenuItem { text: "add computed value to scenario"; onTriggered: mapController.useAsScenarioValue(root.reactionId) }
+        MenuItem { text: "switch to reaction mask"; onTriggered: mapController.switchToReaction(root.reactionId) }
+        MenuSeparator {}
+        MenuItem { text: "remove from map"; onTriggered: mapController.removeBox(root.reactionId) }
+    }
+}

--- a/cnapy/gui_elements/qml_map_view.py
+++ b/cnapy/gui_elements/qml_map_view.py
@@ -1,0 +1,529 @@
+"""Qt Quick based CNApy map view.
+
+This module mirrors the signal and method surface of :mod:`map_view` while
+moving the actual map canvas to the Qt Quick scene graph.  It is intentionally
+feature-flagged by callers so the established QGraphicsView implementation can
+remain the default until the QML path has seen broader testing.
+"""
+
+import importlib.resources as resources
+import math
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from qtpy.QtCore import (QAbstractListModel, QByteArray, QModelIndex, QObject,
+                         Property, QMimeData, QRectF, Qt, QUrl, Signal, Slot)
+from qtpy.QtGui import QColor, QDragEnterEvent, QDropEvent, QGuiApplication
+from qtpy.QtQuickWidgets import QQuickWidget
+from qtpy.QtWidgets import QVBoxLayout, QWidget
+
+from cnapy.appdata import AppData
+from cnapy.gui_elements.map_view import DECREASE_FACTOR, INCREASE_FACTOR, validate_value
+
+
+class ReactionBoxRoles:
+    IdRole = Qt.ItemDataRole.UserRole + 1
+    NameRole = IdRole + 1
+    XRole = NameRole + 1
+    YRole = XRole + 1
+    ValueRole = YRole + 1
+    FillColorRole = ValueRole + 1
+    ForegroundColorRole = FillColorRole + 1
+    SelectedRole = ForegroundColorRole + 1
+    TooltipRole = SelectedRole + 1
+
+
+class ReactionBoxListModel(QAbstractListModel):
+    """List model consumed by the QML reaction-box Repeater."""
+
+    def __init__(self, appdata: AppData, map_name: str, parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self.appdata = appdata
+        self.map_name = map_name
+        self.ids: List[str] = []
+        self.selected_ids = set()
+        self.rebuild()
+
+    def roleNames(self) -> Dict[int, QByteArray]:
+        return {
+            ReactionBoxRoles.IdRole: QByteArray(b"reactionId"),
+            ReactionBoxRoles.NameRole: QByteArray(b"reactionName"),
+            ReactionBoxRoles.XRole: QByteArray(b"boxX"),
+            ReactionBoxRoles.YRole: QByteArray(b"boxY"),
+            ReactionBoxRoles.ValueRole: QByteArray(b"valueText"),
+            ReactionBoxRoles.FillColorRole: QByteArray(b"fillColor"),
+            ReactionBoxRoles.ForegroundColorRole: QByteArray(b"foregroundColor"),
+            ReactionBoxRoles.SelectedRole: QByteArray(b"selected"),
+            ReactionBoxRoles.TooltipRole: QByteArray(b"tooltipText"),
+        }
+
+    def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
+        return 0 if parent.isValid() else len(self.ids)
+
+    def data(self, index: QModelIndex, role: int):
+        if not index.isValid() or index.row() < 0 or index.row() >= len(self.ids):
+            return None
+
+        reaction_id = self.ids[index.row()]
+        boxes = self.appdata.project.maps[self.map_name]["boxes"]
+        if reaction_id not in boxes:
+            return None
+
+        if role == ReactionBoxRoles.IdRole:
+            return reaction_id
+        if role == ReactionBoxRoles.NameRole:
+            return self._reaction_name(reaction_id)
+        if role == ReactionBoxRoles.XRole:
+            return float(boxes[reaction_id][0])
+        if role == ReactionBoxRoles.YRole:
+            return float(boxes[reaction_id][1])
+        if role == ReactionBoxRoles.ValueRole:
+            return self._value_text(reaction_id)
+        if role == ReactionBoxRoles.FillColorRole:
+            return self._fill_color(reaction_id).name(QColor.NameFormat.HexArgb)
+        if role == ReactionBoxRoles.ForegroundColorRole:
+            return self._foreground_color(reaction_id).name(QColor.NameFormat.HexArgb)
+        if role == ReactionBoxRoles.SelectedRole:
+            return reaction_id in self.selected_ids
+        if role == ReactionBoxRoles.TooltipRole:
+            return self._tooltip(reaction_id)
+        return None
+
+    def rebuild(self):
+        self.beginResetModel()
+        self.ids = list(self.appdata.project.maps[self.map_name]["boxes"].keys())
+        self.selected_ids.intersection_update(self.ids)
+        self.endResetModel()
+
+    def index_for_reaction(self, reaction_id: str) -> QModelIndex:
+        if reaction_id not in self.ids:
+            return QModelIndex()
+        return self.index(self.ids.index(reaction_id), 0)
+
+    def emit_reaction_changed(self, reaction_id: str):
+        index = self.index_for_reaction(reaction_id)
+        if index.isValid():
+            self.dataChanged.emit(index, index, list(self.roleNames().keys()))
+
+    def add_or_refresh_reaction(self, reaction_id: str):
+        if reaction_id in self.ids:
+            self.emit_reaction_changed(reaction_id)
+            return
+        row = len(self.ids)
+        self.beginInsertRows(QModelIndex(), row, row)
+        self.ids.append(reaction_id)
+        self.endInsertRows()
+
+    def remove_reaction(self, reaction_id: str):
+        if reaction_id not in self.ids:
+            return
+        row = self.ids.index(reaction_id)
+        self.beginRemoveRows(QModelIndex(), row, row)
+        self.ids.pop(row)
+        self.selected_ids.discard(reaction_id)
+        self.endRemoveRows()
+
+    def set_selected(self, reaction_id: str, selected: bool, exclusive: bool):
+        changed = set(self.selected_ids)
+        if exclusive:
+            self.selected_ids.clear()
+        if selected:
+            self.selected_ids.add(reaction_id)
+        else:
+            self.selected_ids.discard(reaction_id)
+        changed.update(self.selected_ids)
+        for changed_id in changed:
+            self.emit_reaction_changed(changed_id)
+
+    def clear_selection(self):
+        previous = list(self.selected_ids)
+        self.selected_ids.clear()
+        for reaction_id in previous:
+            self.emit_reaction_changed(reaction_id)
+
+    def selected_reactions(self) -> List[str]:
+        return list(self.selected_ids)
+
+    def select_in_rect(self, rect: QRectF, exclusive: bool):
+        if exclusive:
+            self.selected_ids.clear()
+        boxes = self.appdata.project.maps[self.map_name]["boxes"]
+        width = self.appdata.box_width
+        height = self.appdata.box_height
+        for reaction_id, (x, y) in boxes.items():
+            if rect.intersects(QRectF(float(x), float(y), width, height)):
+                self.selected_ids.add(reaction_id)
+        self._emit_all_selected_changed()
+
+    def _emit_all_selected_changed(self):
+        for reaction_id in self.ids:
+            self.emit_reaction_changed(reaction_id)
+
+    def _reaction_name(self, reaction_id: str) -> str:
+        try:
+            return self.appdata.project.cobra_py_model.reactions.get_by_id(reaction_id).name
+        except KeyError:
+            return ""
+
+    def _value_text(self, reaction_id: str) -> str:
+        value = None
+        if reaction_id in self.appdata.project.scen_values:
+            value = self.appdata.project.scen_values[reaction_id]
+        elif reaction_id in self.appdata.project.comp_values:
+            value = self.appdata.project.comp_values[reaction_id]
+        if value is None:
+            return ""
+        vl, vu = value
+        if math.isclose(vl, vu, abs_tol=self.appdata.abs_tol):
+            return str(round(float(vl), self.appdata.rounding)).rstrip("0").rstrip(".")
+        return (str(round(float(vl), self.appdata.rounding)).rstrip("0").rstrip(".")
+                + ", "
+                + str(round(float(vu), self.appdata.rounding)).rstrip("0").rstrip("."))
+
+    def _fill_color(self, reaction_id: str) -> QColor:
+        value_text = self._value_text(reaction_id)
+        if value_text == "":
+            color = QColor(self.appdata.default_color)
+            color.setAlphaF(0.4)
+            return color
+        if not validate_value(value_text):
+            return QColor(Qt.GlobalColor.white)
+        if reaction_id in self.appdata.project.scen_values:
+            return QColor(self.appdata.scen_color)
+        if reaction_id in self.appdata.project.comp_values:
+            vl, vu = self.appdata.project.comp_values[reaction_id]
+            if math.isclose(vl, vu, abs_tol=self.appdata.abs_tol):
+                if self.appdata.modes_coloring:
+                    return QColor(Qt.GlobalColor.red if vl == 0 else Qt.GlobalColor.green)
+                return QColor(self.appdata.comp_color)
+            if (math.isclose(vl, 0.0, abs_tol=self.appdata.abs_tol)
+                    or math.isclose(vu, 0.0, abs_tol=self.appdata.abs_tol)
+                    or (vl <= 0 <= vu)):
+                return QColor(self.appdata.special_color_1)
+            return QColor(self.appdata.special_color_2)
+        return QColor(self.appdata.comp_color)
+
+    def _foreground_color(self, reaction_id: str) -> QColor:
+        value_text = self._value_text(reaction_id)
+        if value_text and not validate_value(value_text):
+            return QColor(self.appdata.scen_color_bad)
+        return QColor(Qt.GlobalColor.black)
+
+    def _tooltip(self, reaction_id: str) -> str:
+        try:
+            r = self.appdata.project.cobra_py_model.reactions.get_by_id(reaction_id)
+        except KeyError:
+            return reaction_id
+        return ("Id: " + r.id + "\nName: " + r.name
+                + "\nEquation: " + r.build_reaction_string()
+                + "\nLowerbound: " + str(r.lower_bound)
+                + "\nUpper bound: " + str(r.upper_bound)
+                + "\nObjective coefficient: " + str(r.objective_coefficient))
+
+
+class QmlMapController(QObject):
+    """Python controller exposed to QML."""
+
+    switchToReactionMask = Signal(str)
+    maximizeReaction = Signal(str)
+    minimizeReaction = Signal(str)
+    setScenValue = Signal(str)
+    reactionRemoved = Signal(str)
+    reactionValueChanged = Signal(str, str)
+    reactionAdded = Signal(str)
+    mapChanged = Signal(str)
+    broadcastReactionID = Signal(str)
+
+    zoomChanged = Signal()
+    boxSizeChanged = Signal()
+    backgroundChanged = Signal()
+    viewportPositionChanged = Signal()
+
+    def __init__(self, appdata: AppData, central_widget, name: str, parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self.appdata = appdata
+        self.central_widget = central_widget
+        self.name = name
+        self.boxes_model = ReactionBoxListModel(appdata, name, self)
+
+    @Property(QObject, constant=True)
+    def reactionBoxes(self):
+        return self.boxes_model
+
+    @Property(float, notify=zoomChanged)
+    def zoomFactor(self) -> float:
+        return INCREASE_FACTOR ** self.appdata.project.maps[self.name]["zoom"]
+
+    @Property(float, notify=boxSizeChanged)
+    def boxScale(self) -> float:
+        return float(self.appdata.project.maps[self.name]["box-size"])
+
+    @Property(float, notify=backgroundChanged)
+    def backgroundScale(self) -> float:
+        return float(self.appdata.project.maps[self.name]["bg-size"])
+
+    @Property(float, constant=True)
+    def boxWidth(self) -> float:
+        return float(self.appdata.box_width)
+
+    @Property(float, constant=True)
+    def boxHeight(self) -> float:
+        return float(self.appdata.box_height)
+
+    @Property(QUrl, notify=backgroundChanged)
+    def backgroundUrl(self) -> QUrl:
+        return QUrl.fromLocalFile(self.appdata.project.maps[self.name]["background"])
+
+    @Property(float, notify=viewportPositionChanged)
+    def contentX(self) -> float:
+        return float(self.appdata.project.maps[self.name]["pos"][0])
+
+    @Property(float, notify=viewportPositionChanged)
+    def contentY(self) -> float:
+        return float(self.appdata.project.maps[self.name]["pos"][1])
+
+    @Slot(float, float)
+    def setViewportPosition(self, x: float, y: float):
+        self.appdata.project.maps[self.name]["pos"] = (x, y)
+        self.viewportPositionChanged.emit()
+
+    @Slot(float, float)
+    def addReactionAt(self, x: float, y: float):
+        mime_data = QGuiApplication.clipboard().mimeData()
+        if mime_data.hasText():
+            self.addReactionFromIdAt(mime_data.text(), x, y)
+
+    @Slot(str, float, float)
+    def addReactionFromIdAt(self, reaction_id: str, x: float, y: float):
+        boxes = self.appdata.project.maps[self.name]["boxes"]
+        is_new = reaction_id not in boxes
+        boxes[reaction_id] = (x, y)
+        self.boxes_model.add_or_refresh_reaction(reaction_id)
+        if is_new:
+            self.reactionAdded.emit(reaction_id)
+        self.mapChanged.emit(reaction_id)
+
+    @Slot(str, float, float)
+    def setBoxPosition(self, reaction_id: str, x: float, y: float):
+        boxes = self.appdata.project.maps[self.name]["boxes"]
+        selected = self.boxes_model.selected_reactions()
+        if reaction_id not in selected:
+            selected = [reaction_id]
+        old_x, old_y = boxes.get(reaction_id, (x, y))
+        dx = x - old_x
+        dy = y - old_y
+        for selected_id in selected:
+            current_x, current_y = boxes[selected_id]
+            boxes[selected_id] = (current_x + dx, current_y + dy)
+            self.boxes_model.emit_reaction_changed(selected_id)
+            self.mapChanged.emit(selected_id)
+
+    @Slot(str, str)
+    def setReactionValue(self, reaction_id: str, value: str):
+        self.reactionValueChanged.emit(reaction_id, value)
+        self.boxes_model.emit_reaction_changed(reaction_id)
+
+    @Slot(str)
+    def removeBox(self, reaction_id: str):
+        boxes = self.appdata.project.maps[self.name]["boxes"]
+        if reaction_id in boxes:
+            del boxes[reaction_id]
+            self.boxes_model.remove_reaction(reaction_id)
+            self.reactionRemoved.emit(reaction_id)
+
+    @Slot(str, bool, bool)
+    def setSelected(self, reaction_id: str, selected: bool, exclusive: bool):
+        self.boxes_model.set_selected(reaction_id, selected, exclusive)
+        if selected:
+            self.broadcastReactionID.emit(reaction_id)
+
+    @Slot()
+    def clearSelection(self):
+        self.boxes_model.clear_selection()
+
+    @Slot(float, float, float, float, bool)
+    def selectRect(self, x: float, y: float, width: float, height: float, exclusive: bool):
+        rect = QRectF(x, y, width, height).normalized()
+        self.boxes_model.select_in_rect(rect, exclusive)
+
+    @Slot(str)
+    def switchToReaction(self, reaction_id: str):
+        self.switchToReactionMask.emit(reaction_id)
+
+    @Slot(str)
+    def maximize(self, reaction_id: str):
+        self.maximizeReaction.emit(reaction_id)
+
+    @Slot(str)
+    def minimize(self, reaction_id: str):
+        self.minimizeReaction.emit(reaction_id)
+
+    @Slot(str)
+    def useAsScenarioValue(self, reaction_id: str):
+        self.setScenValue.emit(reaction_id)
+
+    @Slot(int)
+    def zoomSteps(self, steps: int):
+        maps = self.appdata.project.maps[self.name]
+        maps["zoom"] += steps
+        self.zoomChanged.emit()
+
+    @Slot(float)
+    def scaleBoxesBy(self, factor: float):
+        self.appdata.project.maps[self.name]["box-size"] *= factor
+        self.boxSizeChanged.emit()
+        self.boxes_model._emit_all_selected_changed()
+        self.mapChanged.emit("dummy")
+
+    @Slot()
+    def rebuild(self):
+        self._ensure_background()
+        self.boxes_model.rebuild()
+        self.backgroundChanged.emit()
+        self.boxSizeChanged.emit()
+        self.zoomChanged.emit()
+        self.viewportPositionChanged.emit()
+
+    def _ensure_background(self):
+        maps = self.appdata.project.maps[self.name]
+        if (len(maps["boxes"]) > 0
+                and maps["background"].replace("\\", "/").endswith("/data/default-bg.svg")):
+            with resources.as_file(resources.files("cnapy") / "data" / "blank.svg") as path:
+                maps["background"] = str(path)
+
+    def update_reaction(self, reaction_id: str):
+        self.boxes_model.emit_reaction_changed(reaction_id)
+
+
+class QmlMapView(QWidget):
+    """QWidget-compatible wrapper around the Qt Quick map canvas."""
+
+    switchToReactionMask = Signal(str)
+    maximizeReaction = Signal(str)
+    minimizeReaction = Signal(str)
+    setScenValue = Signal(str)
+    reactionRemoved = Signal(str)
+    reactionValueChanged = Signal(str, str)
+    reactionAdded = Signal(str)
+    mapChanged = Signal(str)
+    broadcastReactionID = Signal(str)
+
+    def __init__(self, appdata: AppData, central_widget, name: str):
+        super().__init__()
+        self.appdata = appdata
+        self.central_widget = central_widget
+        self.name = name
+        self.controller = QmlMapController(appdata, central_widget, name, self)
+        self.quick = QQuickWidget(self)
+        self.quick.setResizeMode(QQuickWidget.ResizeMode.SizeRootObjectToView)
+        self.quick.setAcceptDrops(True)
+        self.setAcceptDrops(True)
+        self.quick.rootContext().setContextProperty("mapController", self.controller)
+        qml_path = Path(__file__).with_name("qml") / "MapView.qml"
+        self.quick.setSource(QUrl.fromLocalFile(str(qml_path)))
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.quick)
+
+        self.controller.switchToReactionMask.connect(self.switchToReactionMask)
+        self.controller.maximizeReaction.connect(self.maximizeReaction)
+        self.controller.minimizeReaction.connect(self.minimizeReaction)
+        self.controller.setScenValue.connect(self.setScenValue)
+        self.controller.reactionRemoved.connect(self.reactionRemoved)
+        self.controller.reactionValueChanged.connect(self.reactionValueChanged)
+        self.controller.reactionAdded.connect(self.reactionAdded)
+        self.controller.mapChanged.connect(self.mapChanged)
+        self.controller.broadcastReactionID.connect(self.broadcastReactionID)
+        self.controller.rebuild()
+
+    def update(self):
+        self.controller.rebuild()
+        super().update()
+
+    def fit(self):
+        root = self.quick.rootObject()
+        if root is not None:
+            root.fitToView()
+
+    def focus_reaction(self, reaction: str):
+        root = self.quick.rootObject()
+        if root is not None and reaction in self.appdata.project.maps[self.name]["boxes"]:
+            x, y = self.appdata.project.maps[self.name]["boxes"][reaction]
+            root.centerOnPoint(float(x), float(y))
+        self.zoom_in_reaction()
+
+    def zoom_in(self):
+        self.appdata.project.maps[self.name]["zoom"] += 1
+        self.controller.zoomChanged.emit()
+
+    def zoom_out(self):
+        self.appdata.project.maps[self.name]["zoom"] -= 1
+        self.controller.zoomChanged.emit()
+
+    def zoom_in_reaction(self):
+        bg_size = self.appdata.project.maps[self.name]["bg-size"]
+        x = (INCREASE_FACTOR ** self.appdata.project.maps[self.name]["zoom"]) / bg_size
+        while x < 1:
+            self.appdata.project.maps[self.name]["zoom"] += 1
+            x = (INCREASE_FACTOR ** self.appdata.project.maps[self.name]["zoom"]) / bg_size
+        self.controller.zoomChanged.emit()
+
+    def select_single_reaction(self, reac_id: str):
+        self.controller.clearSelection()
+        self.controller.setSelected(reac_id, True, True)
+
+    def update_selected(self, found_ids):
+        root = self.quick.rootObject()
+        if root is not None:
+            root.setFilterTerms([str(term).lower() for term in found_ids])
+
+    def highlight_reaction(self, string):
+        self.select_single_reaction(string)
+        self.focus_reaction(string)
+
+    def delete_box(self, reaction_id: str) -> bool:
+        if reaction_id in self.appdata.project.maps[self.name]["boxes"]:
+            self.controller.removeBox(reaction_id)
+            return True
+        return False
+
+    def update_reaction(self, old_reaction_id: str, new_reaction_id: str):
+        boxes = self.appdata.project.maps[self.name]["boxes"]
+        if old_reaction_id in boxes:
+            boxes[new_reaction_id] = boxes.pop(old_reaction_id)
+            self.controller.rebuild()
+
+    def remove_box(self, reaction: str):
+        self.controller.removeBox(reaction)
+
+    def recolor_all(self):
+        self.controller.boxes_model._emit_all_selected_changed()
+
+    def set_values(self):
+        self.controller.boxes_model._emit_all_selected_changed()
+
+    def value_changed(self, reaction: str, value: str):
+        self.controller.setReactionValue(reaction, value)
+
+    def dragEnterEvent(self, event: QDragEnterEvent):
+        if event.mimeData().hasText():
+            event.acceptProposedAction()
+        else:
+            event.ignore()
+
+    def dropEvent(self, event: QDropEvent):
+        mime: QMimeData = event.mimeData()
+        if not mime.hasText():
+            event.ignore()
+            return
+        root = self.quick.rootObject()
+        position = event.position()
+        x = position.x()
+        y = position.y()
+        if root is not None:
+            mapped = root.mapToMapLayer(x, y)
+            x = mapped.x()
+            y = mapped.y()
+        self.controller.addReactionFromIdAt(mime.text(), x, y)
+        event.acceptProposedAction()

--- a/docs/qml-map-view-migration.md
+++ b/docs/qml-map-view-migration.md
@@ -1,0 +1,205 @@
+# QML map view migration notes
+
+This note outlines how `cnapy.gui_elements.map_view.MapView` can be ported from `QGraphicsView` to a Qt Quick scene while keeping the existing Python model and signal API.
+
+## Recommended architecture
+
+1. Keep `MapView` as a compatibility wrapper initially, but make it a `QQuickWidget` or a `QWidget` containing `QQuickWidget` so the rest of `central_widget.py` can still add the map tab as a `QWidget`.
+2. Move map state into a Python `QObject` controller, for example `QmlMapController`, with properties for `zoom`, `boxSize`, `background`, `bgSize`, selected reaction ids, and a `QAbstractListModel` of reaction boxes.
+3. Expose the controller to QML with `engine.rootContext().setContextProperty("mapController", controller)` or register it with `qmlRegisterType`.
+4. Render the map in QML with a `Flickable` for panning, an inner `Item` with a `Scale` transform for zooming, an `Image` for the SVG background, and a `Repeater`/`ListView`-like delegate for reaction boxes.
+5. Keep editing and business logic in Python. QML should call controller slots such as `setBoxPosition()`, `setReactionValue()`, `removeBox()`, `maximizeReaction()`, and `minimizeReaction()`, and the controller should emit the same signals currently emitted by `MapView`.
+
+## Mapping the current implementation
+
+| Current `map_view.py` behavior | QML/Qt Quick equivalent |
+| --- | --- |
+| `QGraphicsView` with `QGraphicsScene` | `QQuickWidget` loading a `MapView.qml` root item |
+| Scroll bars storing `project.maps[name]["pos"]` | `Flickable.contentX` and `Flickable.contentY` bound through controller properties |
+| `QGraphicsSvgItem` background | QML `Image { source: controller.backgroundUrl; scale: controller.bgSize }` |
+| `ReactionBox(QGraphicsItem)` plus `QGraphicsProxyWidget`/`QLineEdit` | QML delegate containing `Rectangle`, `TextInput`, `MouseArea`, and `DragHandler` |
+| Rubber-band selection | QML transparent `Rectangle` plus controller hit testing, or `SelectionRectangle` if available in the target Qt version |
+| Context `QMenu` on each line edit | QML `Menu` from Qt Quick Controls, calling Python slots |
+| `mapChanged`, `reactionValueChanged`, and related signals | Re-emitted by the Python controller to preserve `CentralWidget.connect_map_view_signals()` |
+
+## Minimal Python wrapper sketch
+
+```python
+from pathlib import Path
+
+from qtpy.QtCore import QObject, Property, QAbstractListModel, QModelIndex, Qt, Signal, Slot, QUrl
+from qtpy.QtQuickWidgets import QQuickWidget
+from qtpy.QtWidgets import QWidget, QVBoxLayout
+
+
+class ReactionBoxModel(QAbstractListModel):
+    IdRole = Qt.ItemDataRole.UserRole + 1
+    NameRole = IdRole + 1
+    XRole = NameRole + 1
+    YRole = XRole + 1
+    ValueRole = YRole + 1
+    ColorRole = ValueRole + 1
+    SelectedRole = ColorRole + 1
+
+    def __init__(self, appdata, map_name, parent=None):
+        super().__init__(parent)
+        self.appdata = appdata
+        self.map_name = map_name
+        self.ids = list(appdata.project.maps[map_name]["boxes"])
+
+    def roleNames(self):
+        return {
+            self.IdRole: b"reactionId",
+            self.NameRole: b"reactionName",
+            self.XRole: b"boxX",
+            self.YRole: b"boxY",
+            self.ValueRole: b"valueText",
+            self.ColorRole: b"boxColor",
+            self.SelectedRole: b"selected",
+        }
+
+    def rowCount(self, parent=QModelIndex()):
+        return 0 if parent.isValid() else len(self.ids)
+
+    def data(self, index, role):
+        if not index.isValid():
+            return None
+        reaction_id = self.ids[index.row()]
+        boxes = self.appdata.project.maps[self.map_name]["boxes"]
+        if role == self.IdRole:
+            return reaction_id
+        if role == self.XRole:
+            return boxes[reaction_id][0]
+        if role == self.YRole:
+            return boxes[reaction_id][1]
+        # Fill name, value, color, and selected state from appdata/project here.
+        return None
+
+
+class QmlMapController(QObject):
+    mapChanged = Signal(str)
+    reactionValueChanged = Signal(str, str)
+    reactionAdded = Signal(str)
+    reactionRemoved = Signal(str)
+    switchToReactionMask = Signal(str)
+    maximizeReaction = Signal(str)
+    minimizeReaction = Signal(str)
+    setScenValue = Signal(str)
+
+    zoomChanged = Signal()
+    boxSizeChanged = Signal()
+    backgroundChanged = Signal()
+
+    def __init__(self, appdata, central_widget, name, parent=None):
+        super().__init__(parent)
+        self.appdata = appdata
+        self.central_widget = central_widget
+        self.name = name
+        self.boxes = ReactionBoxModel(appdata, name, self)
+
+    @Property(QObject, constant=True)
+    def reactionBoxes(self):
+        return self.boxes
+
+    @Property(float, notify=zoomChanged)
+    def zoom(self):
+        return self.appdata.project.maps[self.name]["zoom"]
+
+    @Slot(str, float, float)
+    def setBoxPosition(self, reaction_id, x, y):
+        self.appdata.project.maps[self.name]["boxes"][reaction_id] = (x, y)
+        self.mapChanged.emit(reaction_id)
+
+    @Slot(str, str)
+    def setReactionValue(self, reaction_id, value):
+        # Reuse validate_value() and the existing Python value update path.
+        self.reactionValueChanged.emit(reaction_id, value)
+
+
+class QmlMapView(QWidget):
+    def __init__(self, appdata, central_widget, name, parent=None):
+        super().__init__(parent)
+        self.controller = QmlMapController(appdata, central_widget, name, self)
+        self.quick = QQuickWidget(self)
+        self.quick.setResizeMode(QQuickWidget.ResizeMode.SizeRootObjectToView)
+        self.quick.rootContext().setContextProperty("mapController", self.controller)
+        self.quick.setSource(QUrl.fromLocalFile(str(Path(__file__).with_name("MapView.qml"))))
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.quick)
+```
+
+## Minimal QML sketch
+
+```qml
+import QtQuick
+import QtQuick.Controls
+
+Item {
+    id: root
+    focus: true
+
+    Flickable {
+        id: flick
+        anchors.fill: parent
+        contentWidth: mapLayer.width * mapLayer.scale
+        contentHeight: mapLayer.height * mapLayer.scale
+        boundsBehavior: Flickable.StopAtBounds
+
+        Item {
+            id: mapLayer
+            width: background.implicitWidth
+            height: background.implicitHeight
+            scale: Math.pow(1.1, mapController.zoom)
+
+            Image {
+                id: background
+                source: mapController.backgroundUrl
+                asynchronous: true
+                cache: true
+            }
+
+            Repeater {
+                model: mapController.reactionBoxes
+                delegate: ReactionBoxDelegate {
+                    x: boxX
+                    y: boxY
+                    reactionId: model.reactionId
+                    reactionName: model.reactionName
+                    valueText: model.valueText
+                    selected: model.selected
+                    onMoved: (newX, newY) => mapController.setBoxPosition(reactionId, newX, newY)
+                    onValueEdited: value => mapController.setReactionValue(reactionId, value)
+                }
+            }
+        }
+    }
+
+    WheelHandler {
+        acceptedModifiers: Qt.NoModifier
+        onWheel: event => mapController.zoomBy(event.angleDelta.y > 0 ? 1 : -1)
+    }
+
+    WheelHandler {
+        acceptedModifiers: Qt.ControlModifier
+        onWheel: event => mapController.scaleBoxes(event.angleDelta.y > 0 ? 1.1 : 1 / 1.1)
+    }
+}
+```
+
+## Migration order
+
+1. Add `QmlMapView` beside the existing `MapView` and keep the old class untouched.
+2. Implement the list model and controller signals until `CentralWidget.connect_map_view_signals()` can connect to either implementation.
+3. Port only panning, zooming, background, and read-only reaction boxes first.
+4. Add editing, selection, context menus, drag-and-drop from the reaction list, and hit testing.
+5. Add a feature flag or config option to switch between the existing widget and QML implementation.
+6. Benchmark with a large map before deleting the `QGraphicsView` implementation.
+
+## Important caveats
+
+* `QQuickWidget` embeds a Qt Quick scene into a QWidget UI but can incur extra offscreen rendering. For maximum throughput, a full `QQuickView`/`QQuickWindow` architecture is faster, but it is more invasive for the current tab-based QWidget UI.
+* A QML `TextInput` is not a `QLineEdit`; validation, focus behavior, and editing history should stay in the Python controller to avoid divergent behavior.
+* Qt Quick does not accelerate arbitrary Python painting. The performance win comes from replacing per-item `QPainter`/proxy-widget rendering with QML scene graph items, batched rectangles, text, images, and transforms.
+* SVG rendering may still be CPU-bound when initially rasterized. For huge SVG backgrounds, consider pre-rendering tiles or using a cached image texture.


### PR DESCRIPTION
### Motivation
- Introduce an experimental Qt Quick / QML based map canvas to enable a hardware-accelerated rendering path while preserving the existing `QGraphicsView` implementation as the default. 
- Provide a smooth migration path so the rest of the codebase can treat either backend as a drop-in map widget.

### Description
- Add a new `QmlMapView` implementation in `cnapy/gui_elements/qml_map_view.py` which exposes a `QmlMapController` and `ReactionBoxListModel` to QML and mirrors the `MapView` API and signals. 
- Add QML UI files `qml/MapView.qml` and `qml/ReactionBoxDelegate.qml` that render the map background, reaction boxes, panning/zooming, selection, context menu and drag/drop behavior. 
- Introduce factory/helper functions `create_cnapy_map_view` and `is_cnapy_map_view` in `central_widget.py`, use them where `MapView` was constructed or type-checked, and keep existing `MapView` behavior as the default; enable QML path when `CNAPY_QML_MAP_VIEW=1`. 
- Update `main_window.py` to import and use the factory and type helper, and add migration documentation `docs/qml-map-view-migration.md` describing architecture and porting notes.

### Testing
- Ran the project's automated test suite with `pytest` which completed successfully. 
- Performed an automated syntax/compile check with `python -m compileall .` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a80751538bc8327b2108c50362de601)